### PR TITLE
[Feat] HapticClient 구현

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -65,7 +65,7 @@ colon:
 
 # 행 길이 커스텀 정의
 line_length:
-  warning: 120 # 99자 이상 시 워닝
+  warning: 120 # 120자 이상 시 워닝
   ignores_urls: true # URL에 대해 행 길이 제한 미적용
   ignores_comments: true # 코멘트에 대해 행 길이 제한 미적용
   ignores_interpolated_strings: true # 보간된 문자열 행 길이 제한 미적용

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -65,7 +65,7 @@ colon:
 
 # 행 길이 커스텀 정의
 line_length:
-  warning: 99 # 99자 이상 시 워닝
+  warning: 120 # 99자 이상 시 워닝
   ignores_urls: true # URL에 대해 행 길이 제한 미적용
   ignores_comments: true # 코멘트에 대해 행 길이 제한 미적용
   ignores_interpolated_strings: true # 보간된 문자열 행 길이 제한 미적용

--- a/Projects/Core/Services/Haptic/HapticClient.swift
+++ b/Projects/Core/Services/Haptic/HapticClient.swift
@@ -24,7 +24,6 @@ public extension DependencyValues {
   }
 }
 
-
 // MARK: - API Client Implementation
 extension HapticClient: DependencyKey {
   public static let liveValue = HapticClient(

--- a/Projects/Core/Services/Haptic/HapticClient.swift
+++ b/Projects/Core/Services/Haptic/HapticClient.swift
@@ -1,0 +1,44 @@
+//
+//  HapticClient.swift
+//  Services
+//
+//  Created by GREEN on 6/8/24.
+//  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
+//
+
+import ComposableArchitecture
+import SwiftUI
+
+// MARK: - API Client Interface
+public struct HapticClient {
+  /// 사용자 인터랙션에 따른 햅틱 반응 (light || medium || heavy || soft || rigid)
+  public var triggerImpact: @Sendable (UIImpactFeedbackGenerator.FeedbackStyle) async -> Void
+  /// 작업 완료 여부에 따른 햅틱 반응 (success || warning || error)
+  public var triggerNotification: @Sendable (UINotificationFeedbackGenerator.FeedbackType) async -> Void
+}
+
+public extension DependencyValues {
+  var hapticClient: HapticClient {
+    get { self[HapticClient.self] }
+    set { self[HapticClient.self] = newValue }
+  }
+}
+
+
+// MARK: - API Client Implementation
+extension HapticClient: DependencyKey {
+  public static let liveValue = HapticClient(
+    triggerImpact: { style in
+      await MainActor.run {
+        let generator = UIImpactFeedbackGenerator(style: style)
+        generator.impactOccurred()
+      }
+    },
+    triggerNotification: { type in
+      await MainActor.run {
+        let generator = UINotificationFeedbackGenerator()
+        generator.notificationOccurred(type)
+      }
+    }
+  )
+}

--- a/Projects/Core/Services/Haptic/HapticClient.swift
+++ b/Projects/Core/Services/Haptic/HapticClient.swift
@@ -28,16 +28,12 @@ public extension DependencyValues {
 extension HapticClient: DependencyKey {
   public static let liveValue = HapticClient(
     triggerImpact: { style in
-      await MainActor.run {
-        let generator = UIImpactFeedbackGenerator(style: style)
-        generator.impactOccurred()
-      }
+      let generator = await UIImpactFeedbackGenerator(style: style)
+      await generator.impactOccurred()
     },
     triggerNotification: { type in
-      await MainActor.run {
-        let generator = UINotificationFeedbackGenerator()
-        generator.notificationOccurred(type)
-      }
+      let generator = await UINotificationFeedbackGenerator()
+      await generator.notificationOccurred(type)
     }
   )
 }


### PR DESCRIPTION
## 📌 Related Issue
- #31 

## 🚀 Description
- 추후 햅틱 니즈에 따른 햅틱 클라이언트 구현
- 99자 제한이 생각보다 빠듯하여 120자로 린트 수정

## 📢 Notes
- 햅틱 종류는 크게 두가지로 notification과 impact를 대개 사용
  - 작업 여부에 따라 성공/경고/에러 정의된 케이스를 넘기는 notification을 사용할 수 있음 (강도 조절등은 이미 특정하게 지정되어 하지 못함)
  - 우리가 실제적으로 사용하게될 부분은 5가지 햅틱 강도를 가진 impact를 활용할것으로 보임
  - 우선 두가지 모두 구현해두었고 추후 필요한 기능을 사용하면 될듯
- 아래와 같이 호출하여 사용할 수 있음
  ```swift
  // Reducer 구현부
  ...
  @Dependency(\.hapticClient) var hapticClient
  ...
  case .hapticFeedback:
    return .run { _ in
      await hapticClient.triggerImpact(.heavy)
    }
  ...
  ```