### PR TITLE
[Feat] 사진 앨범 기능 및 사진 권한 확인/요청 서비스 객체 구현

### DIFF
--- a/Projects/App/Info.plist
+++ b/Projects/App/Info.plist
@@ -9,6 +9,10 @@
 	</dict>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>$(PRODUCT_NAME)앱이 사진을 가져오기 위해 앨범 접근 권한을 허용해주세요.</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleName</key>

--- a/Projects/Core/Services/Haptic/HapticClient.swift
+++ b/Projects/Core/Services/Haptic/HapticClient.swift
@@ -30,7 +30,9 @@ extension HapticClient: DependencyKey {
       await generator.notificationOccurred(type)
     }
   )
-  
+}
+
+extension HapticClient: TestDependencyKey {
   public static let testValue = Self()
 }
 

--- a/Projects/Core/Services/Haptic/HapticClient.swift
+++ b/Projects/Core/Services/Haptic/HapticClient.swift
@@ -17,13 +17,6 @@ public struct HapticClient {
   public var triggerNotification: @Sendable (UINotificationFeedbackGenerator.FeedbackType) async -> Void
 }
 
-public extension DependencyValues {
-  var hapticClient: HapticClient {
-    get { self[HapticClient.self] }
-    set { self[HapticClient.self] = newValue }
-  }
-}
-
 // MARK: - API Client Implementation
 extension HapticClient: DependencyKey {
   public static let liveValue = HapticClient(
@@ -36,4 +29,16 @@ extension HapticClient: DependencyKey {
       await generator.notificationOccurred(type)
     }
   )
+  
+  public static let testValue = HapticClient(
+    triggerImpact: unimplemented("\(Self.self).triggerImpact"),
+    triggerNotification: unimplemented("\(Self.self).triggerNotification")
+  )
+}
+
+public extension DependencyValues {
+  var hapticClient: HapticClient {
+    get { self[HapticClient.self] }
+    set { self[HapticClient.self] = newValue }
+  }
 }

--- a/Projects/Core/Services/Haptic/HapticClient.swift
+++ b/Projects/Core/Services/Haptic/HapticClient.swift
@@ -10,6 +10,7 @@ import ComposableArchitecture
 import SwiftUI
 
 // MARK: - API Client Interface
+@DependencyClient
 public struct HapticClient {
   /// 사용자 인터랙션에 따른 햅틱 반응 (light || medium || heavy || soft || rigid)
   public var triggerImpact: @Sendable (UIImpactFeedbackGenerator.FeedbackStyle) async -> Void

--- a/Projects/Core/Services/Haptic/HapticClient.swift
+++ b/Projects/Core/Services/Haptic/HapticClient.swift
@@ -30,10 +30,7 @@ extension HapticClient: DependencyKey {
     }
   )
   
-  public static let testValue = HapticClient(
-    triggerImpact: unimplemented("\(Self.self).triggerImpact"),
-    triggerNotification: unimplemented("\(Self.self).triggerNotification")
-  )
+  public static let testValue = Self()
 }
 
 public extension DependencyValues {

--- a/Projects/Core/Services/PhotoClient/PhotoClient.swift
+++ b/Projects/Core/Services/PhotoClient/PhotoClient.swift
@@ -1,0 +1,74 @@
+//
+//  PhotoClient.swift
+//  Services
+//
+//  Created by GREEN on 6/12/24.
+//  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
+//
+
+import ComposableArchitecture
+import Photos
+import SwiftUI
+
+// MARK: - API Client Interface
+@DependencyClient
+public struct PhotoClient {
+  public var checkPhotoLibraryAuthorization: @Sendable () async throws -> Result<Bool, Error>
+  public var requestPhotoLibraryAccess: @Sendable () async throws -> Result<Bool, Error>
+}
+
+// MARK: - API Client Implementation
+extension PhotoClient: DependencyKey {
+  public static let liveValue = PhotoClient(
+    checkPhotoLibraryAuthorization: {
+      let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+      return try await handleStatus(status)
+    },
+    requestPhotoLibraryAccess: {
+      let status = await PHPhotoLibrary.requestAuthorization(for: .readWrite)
+      return try await handleStatus(status)
+    }
+  )
+  
+  public static let testValue = PhotoClient(
+    checkPhotoLibraryAuthorization: unimplemented("\(Self.self).checkPhotoLibraryAuthorization"),
+    requestPhotoLibraryAccess: unimplemented("\(Self.self).requestPhotoLibraryAccess")
+  )
+  
+  private static func handleStatus(_ status: PHAuthorizationStatus) async throws -> Result<Bool, Error> {
+    switch status {
+    case .authorized, .limited:
+      return .success(true)
+    default:
+      return .failure(PhotoClientError(code: .notAccessPhotoLibrary))
+    }
+  }
+}
+
+public extension DependencyValues {
+  var photoClient: PhotoClient {
+    get { self[PhotoClient.self] }
+    set { self[PhotoClient.self] = newValue }
+  }
+}
+
+// MARK: - PhotoClient Error
+public struct PhotoClientError: GabbangzipError {
+  public var userInfo: [String: Any]
+  public var code: Code
+  public var underlying: Error?
+  
+  public init(
+    userInfo: [String: Any] = [:],
+    code: Code,
+    underlying: Error? = nil
+  ) {
+    self.userInfo = userInfo
+    self.code = code
+    self.underlying = underlying
+  }
+  
+  public enum Code: Int {
+    case notAccessPhotoLibrary = 0
+  }
+}

--- a/Projects/Core/Services/PhotoClient/PhotoClient.swift
+++ b/Projects/Core/Services/PhotoClient/PhotoClient.swift
@@ -13,8 +13,8 @@ import SwiftUI
 // MARK: - API Client Interface
 @DependencyClient
 public struct PhotoClient {
-  public var checkPhotoLibraryAuthorization: @Sendable () async throws -> Result<Bool, Error>
-  public var requestPhotoLibraryAccess: @Sendable () async throws -> Result<Bool, Error>
+  public var checkPhotoLibraryAuthorization: @Sendable () async throws -> Bool
+  public var requestPhotoLibraryAccess: @Sendable () async throws -> Bool
 }
 
 // MARK: - API Client Implementation
@@ -35,12 +35,12 @@ extension PhotoClient: DependencyKey {
     requestPhotoLibraryAccess: unimplemented("\(Self.self).requestPhotoLibraryAccess")
   )
   
-  private static func handleStatus(_ status: PHAuthorizationStatus) async throws -> Result<Bool, Error> {
+  private static func handleStatus(_ status: PHAuthorizationStatus) async throws -> Bool {
     switch status {
     case .authorized, .limited:
-      return .success(true)
+      return true
     default:
-      return .failure(PhotoClientError(code: .notAccessPhotoLibrary))
+      throw PhotoClientError(code: .notAccessPhotoLibrary)
     }
   }
 }

--- a/Projects/Core/Services/PhotoClient/PhotoClient.swift
+++ b/Projects/Core/Services/PhotoClient/PhotoClient.swift
@@ -30,8 +30,6 @@ extension PhotoClient: DependencyKey {
     }
   )
   
-  public static let testValue = Self()
-  
   private static func handleStatus(_ status: PHAuthorizationStatus) async throws -> Bool {
     switch status {
     case .authorized, .limited:
@@ -40,6 +38,10 @@ extension PhotoClient: DependencyKey {
       throw PhotoClientError(code: .notAccessPhotoLibrary)
     }
   }
+}
+
+extension PhotoClient: TestDependencyKey {
+  public static let testValue = Self()
 }
 
 public extension DependencyValues {

--- a/Projects/Core/Services/PhotoClient/PhotoClient.swift
+++ b/Projects/Core/Services/PhotoClient/PhotoClient.swift
@@ -30,10 +30,7 @@ extension PhotoClient: DependencyKey {
     }
   )
   
-  public static let testValue = PhotoClient(
-    checkPhotoLibraryAuthorization: unimplemented("\(Self.self).checkPhotoLibraryAuthorization"),
-    requestPhotoLibraryAccess: unimplemented("\(Self.self).requestPhotoLibraryAccess")
-  )
+  public static let testValue = Self()
   
   private static func handleStatus(_ status: PHAuthorizationStatus) async throws -> Bool {
     switch status {

--- a/Projects/Core/Services/SnapshotClient/SnapshotClient.swift
+++ b/Projects/Core/Services/SnapshotClient/SnapshotClient.swift
@@ -15,13 +15,6 @@ public struct SnapshotClient {
   public var takeSnapshot: @Sendable () async throws -> UIImage
 }
 
-public extension DependencyValues {
-  var snapshotClient: SnapshotClient {
-    get { self[SnapshotClient.self] }
-    set { self[SnapshotClient.self] = newValue }
-  }
-}
-
 // MARK: - API Client Implementation
 extension SnapshotClient: DependencyKey {
   public static let liveValue = SnapshotClient(
@@ -49,6 +42,17 @@ extension SnapshotClient: DependencyKey {
       }
     }
   )
+  
+  public static let testValue = SnapshotClient(
+    takeSnapshot: unimplemented("\(Self.self).takeSnapshot")
+  )
+}
+
+public extension DependencyValues {
+  var snapshotClient: SnapshotClient {
+    get { self[SnapshotClient.self] }
+    set { self[SnapshotClient.self] = newValue }
+  }
 }
 
 // MARK: - Snapshot Error

--- a/Projects/Core/Services/SnapshotClient/SnapshotClient.swift
+++ b/Projects/Core/Services/SnapshotClient/SnapshotClient.swift
@@ -43,9 +43,7 @@ extension SnapshotClient: DependencyKey {
     }
   )
   
-  public static let testValue = SnapshotClient(
-    takeSnapshot: unimplemented("\(Self.self).takeSnapshot")
-  )
+  public static let testValue = Self()
 }
 
 public extension DependencyValues {

--- a/Projects/Core/Services/SnapshotClient/SnapshotClient.swift
+++ b/Projects/Core/Services/SnapshotClient/SnapshotClient.swift
@@ -42,7 +42,9 @@ extension SnapshotClient: DependencyKey {
       }
     }
   )
-  
+}
+
+extension SnapshotClient: TestDependencyKey {
   public static let testValue = Self()
 }
 

--- a/Projects/DesignSystem/Sources/Views/PhotoPicker/GabbangzipPhotoPicker.swift
+++ b/Projects/DesignSystem/Sources/Views/PhotoPicker/GabbangzipPhotoPicker.swift
@@ -10,7 +10,7 @@ import PhotosUI
 import SwiftUI
 
 public struct GabbangzipPhotoPicker<Content: View>: View {
-  @State private var selectedPhotos: [PhotosPickerItem]
+  @State private var selectedPhotos: [PhotosPickerItem] = []
   @Binding private var selectedImages: [UIImage]
   @Binding private var isPresentedError: Bool
   private let maxSelectedCount: MaxSelectedCountType
@@ -25,7 +25,6 @@ public struct GabbangzipPhotoPicker<Content: View>: View {
   private let content: () -> Content
   
   public init(
-    selectedPhotos: [PhotosPickerItem] = [],
     selectedImages: Binding<[UIImage]>,
     isPresentedError: Binding<Bool> = .constant(false),
     maxSelectedCount: MaxSelectedCountType = .multiple,
@@ -33,7 +32,6 @@ public struct GabbangzipPhotoPicker<Content: View>: View {
     photoLibrary: PHPhotoLibrary = .shared(),
     content: @escaping () -> Content
   ) {
-    self.selectedPhotos = selectedPhotos
     self._selectedImages = selectedImages
     self._isPresentedError = isPresentedError
     self.maxSelectedCount = maxSelectedCount

--- a/Projects/DesignSystem/Sources/Views/PhotoPicker/GabbangzipPhotoPicker.swift
+++ b/Projects/DesignSystem/Sources/Views/PhotoPicker/GabbangzipPhotoPicker.swift
@@ -1,0 +1,81 @@
+//
+//  GabbangzipPhotoPicker.swift
+//  DesignSystem
+//
+//  Created by GREEN on 6/12/24.
+//  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
+//
+
+import PhotosUI
+import SwiftUI
+
+public struct GabbangzipPhotoPicker<Content: View>: View {
+  @State private var selectedPhotos: [PhotosPickerItem]
+  @Binding private var selectedImages: [UIImage]
+  @Binding private var isPresentedError: Bool
+  private let maxSelectedCount: MaxSelectedCountType
+  private var disabled: Bool {
+    selectedImages.count >= maxSelectedCount.rawValue
+  }
+  private var availableSelectedCount: Int {
+    maxSelectedCount.rawValue - selectedImages.count
+  }
+  private let matching: PHPickerFilter
+  private let photoLibrary: PHPhotoLibrary
+  private let content: () -> Content
+  
+  public init(
+    selectedPhotos: [PhotosPickerItem] = [],
+    selectedImages: Binding<[UIImage]>,
+    isPresentedError: Binding<Bool> = .constant(false),
+    maxSelectedCount: MaxSelectedCountType = .multiple,
+    matching: PHPickerFilter = .images,
+    photoLibrary: PHPhotoLibrary = .shared(),
+    content: @escaping () -> Content
+  ) {
+    self.selectedPhotos = selectedPhotos
+    self._selectedImages = selectedImages
+    self._isPresentedError = isPresentedError
+    self.maxSelectedCount = maxSelectedCount
+    self.matching = matching
+    self.photoLibrary = photoLibrary
+    self.content = content
+  }
+  
+  public var body: some View {
+    PhotosPicker(
+      selection: $selectedPhotos,
+      maxSelectionCount: availableSelectedCount,
+      matching: matching,
+      photoLibrary: photoLibrary
+    ) {
+      content()
+        .disabled(disabled)
+    }
+    .disabled(disabled)
+    .onChange(of: selectedPhotos) { _, newValue in
+      handleSelectedPhotos(newValue)
+    }
+  }
+  
+  private func handleSelectedPhotos(_ newPhotos: [PhotosPickerItem]) {
+    for newPhoto in newPhotos {
+      newPhoto.loadTransferable(type: Data.self) { result in
+        switch result {
+        case .success(let data):
+          if let data = data, let newImage = UIImage(data: data) {
+            if !selectedImages.contains(where: { $0.pngData() == newImage.pngData() }) {
+              DispatchQueue.main.async {
+                selectedImages.append(newImage)
+              }
+            }
+          }
+        case .failure:
+          isPresentedError = true
+        }
+      }
+    }
+    
+    selectedPhotos.removeAll()
+  }
+}

--- a/Projects/DesignSystem/Sources/Views/PhotoPicker/MaxSelectedCountType.swift
+++ b/Projects/DesignSystem/Sources/Views/PhotoPicker/MaxSelectedCountType.swift
@@ -1,0 +1,27 @@
+//
+//  MaxSelectedCountType.swift
+//  DesignSystem
+//
+//  Created by GREEN on 6/12/24.
+//  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - 최대 선택 사진 갯수 타입
+public enum MaxSelectedCountType {
+  case single
+  case multiple
+  case custom(Int)
+  
+  var rawValue: Int {
+    switch self {
+    case .single:
+      return 1
+    case .multiple:
+      return 6
+    case .custom(let value):
+      return value
+    }
+  }
+}


### PR DESCRIPTION
## 📌 Related Issue
- #35 

## 🚀 Description
- 사진 앨범 커스텀 뷰 및 기능 구현
- 사진 권한 확인 및 요청 서비스 객체 구현
- 서비스 객체 코드 순서 통일

## 📸 Screenshot
![Simulator Screen Recording - iPhone 15 - 2024-06-12 at 09 41 43](https://github.com/mash-up-kr/gabbangzip-iOS/assets/72292617/16bee05f-f75b-4041-aa3e-b5132caf4f8f)

## 📢 Notes
- 사진 앨범 커스텀 뷰 사용 시 아래와 같이 사용할 수 있습니다.
```swift
GabbangzipPhotoPicker(selectedImages: $selectedImages) {
  Text("사진 골라")
    .padding()
    .background(Color.green)
    .foregroundColor(.white)
     .cornerRadius(10)
}
```
View를 제네릭하게 받음으로 해당 사진 앨범 시트를 띄울 매개체가 되는 뷰를 넣으면 됩니다.
사진 앨범 접근은 기본적으로 modal sheet로 노출되기에 별도 .sheet에 담을 필요가 없습니다.
사진 앨범은 현재 기획상 1장 혹은 6장에 맞췄으며, 추가로 커스텀하게 최대 선택 수를 커스텀하게 설정할 수 있게 타입을 나눴습니다.
이미 선택된 사진은 중복 체크되지 않습니다. (중복 선택을 허용하지 않을것 같은데 추후 기획이 확정되면 변경해도 됩니다.)
마지막으로, 바인딩으로 전달해야할 항목은 선택된 이미지인 selectedImages 값과 사진 가져오기 시 에러 발생에 대응하기 위한 isPresentedError값을 가짐으로 State에서 바인딩하여 처리하면 될것 같습니다.
(에러 시 얼럿을 띄워주는것 + 사진 삭제 시 selectedImages 업데이트 등)
사진 권한은 권한 존재 여부 확인 및 요청 시나리오 로직을 가지며, 적절히 리듀서에서 Result 결과에 따라 후속 처리하여 사용하면 됩니다.