### PR TITLE
[Feat] Persisted shared state(In-memory) 적용

### DIFF
--- a/Projects/App/Sources/RootCore.swift
+++ b/Projects/App/Sources/RootCore.swift
@@ -27,11 +27,14 @@ public struct RootCore {
   @ObservableState
   public struct State {
     @Presents var destination: Destination.State?
+    @Shared var userInfo: UserInfo
     
     public init(
-      destination: Destination.State? = nil
+      destination: Destination.State? = nil,
+      userInfo: @autoclosure () -> UserInfo = .defaultValue
     ) {
       self.destination = destination
+      self._userInfo = Shared(wrappedValue: userInfo(), .inMemory("userInfo"))
     }
   }
   
@@ -44,10 +47,9 @@ public struct RootCore {
     case onOpenURL(URL)
     
     // Internal Action
-    case readUserInfo(Result<UserInfo, Error>)
-    case readRefreshToken(Result<String, Error>)
-    case checkAccessToken(Result<TestInfo, Error>)
-    case refreshToken(Result<TokenInfo, Error>)
+    case getUserInfoFromKeyChain(Result<UserInfo, Error>)
+    case checkAccessToken(Result<TestInfo, Error>, userInfo: UserInfo)
+    case refreshToken(Result<TokenInfo, Error>, userInfo: UserInfo)
     case logError(RootCoreError)
     case setDestination(Destination.State?)
   }
@@ -78,7 +80,7 @@ public struct RootCore {
         
       case .onAppear:
         return .run { send in
-          await send(.readUserInfo(Result { try await self.keyChainClient.readUserInfo() }))
+          await send(.getUserInfoFromKeyChain(Result { try await self.keyChainClient.readUserInfo() }))
         }
         
       case let .onOpenURL(url):
@@ -90,49 +92,52 @@ public struct RootCore {
           }
         }
         
-      case let .readUserInfo(.success(userInfo)):
+      case let .getUserInfoFromKeyChain(.success(userInfo)):
         return .run { send in
-          await send(.checkAccessToken(Result { try await self.authAPIClient.testToken(userInfo.accessToken) }))
+          await send(
+            .checkAccessToken(
+              Result { try await self.authAPIClient.testToken(userInfo.accessToken) }, 
+              userInfo: userInfo
+            )
+          )
         }
         
-      case .readUserInfo(.failure):
+      case .getUserInfoFromKeyChain(.failure):
         state.destination = .login(LoginCore.State())
         return .none
         
-      case let .readRefreshToken(.success(refreshToken)):
-        return .run { send in
-          await send(.refreshToken(Result { try await self.authAPIClient.refreshToken(refreshToken) }))
-        }
-        
-      case .readRefreshToken(.failure):
-        state.destination = .login(LoginCore.State())
-        return .none
-        
-      case .checkAccessToken(.success):
+      case let .checkAccessToken(.success, userInfo):
+        state.userInfo = userInfo
         state.destination = .mainCoordinator(MainCoordinatorCore.State(routes: [.root(.groupList(GroupListCore.State()), embedInNavigationView: true)]))
         return .none
         
-      case .checkAccessToken(.failure):
+      case let .checkAccessToken(.failure, userInfo):
         return .run { send in
-          await send(.readRefreshToken(Result { try await self.keyChainClient.readUserInfo().refreshToken }))
+          await send(
+            .refreshToken(
+              Result { try await self.authAPIClient.refreshToken(userInfo.refreshToken) },
+              userInfo: userInfo)
+          )
         }
         
-      case let .refreshToken(.success(tokenInformation)):
+      case let .refreshToken(.success(tokenInformation), userInfo):
+        var newUserInfo = userInfo
+        newUserInfo.update(keyPath: \.accessToken, value: tokenInformation.accessToken)
+        newUserInfo.update(keyPath: \.refreshToken, value: tokenInformation.refreshToken)
+        state.userInfo = newUserInfo
+        
         return .run(
-          operation: { send in
-            var userInfo = try await self.keyChainClient.readUserInfo()
-            userInfo.update(keyPath: \.accessToken, value: tokenInformation.accessToken)
-            userInfo.update(keyPath: \.refreshToken, value: tokenInformation.refreshToken)
-            try await keyChainClient.updateUserInfo(userInfo)
+          operation: { [newUserInfo] send in
+            try await keyChainClient.updateUserInfo(newUserInfo)
             await send(.setDestination(.mainCoordinator(MainCoordinatorCore.State(routes: [.root(.groupList(GroupListCore.State()), embedInNavigationView: true)]))))
           },
-          catch: { error ,send in
+          catch: { error, send in
             await send(.setDestination(.login(LoginCore.State())))
             await send(.logError(RootCoreError(code: .failToSaveToken)))
           }
         )
         
-      case .refreshToken(.failure):
+      case .refreshToken(.failure, _):
         state.destination = .login(LoginCore.State())
         return .none
         

--- a/Projects/Core/Models/Shared/UserInfo.swift
+++ b/Projects/Core/Models/Shared/UserInfo.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct UserInfo: Codable {
+public struct UserInfo: Codable, Equatable {
   public var userID: Int
   public var nickname: String
   public var accessToken: String
@@ -24,4 +24,6 @@ public struct UserInfo: Codable {
   public mutating func update<T>(keyPath: WritableKeyPath<UserInfo, T>, value: T) {
     self[keyPath: keyPath] = value
   }
+  
+  public static let defaultValue = UserInfo(userID: -1, nickname: "", accessToken: "", refreshToken: "")
 }

--- a/Projects/Features/Scene/CreateGroupScene/SelectGroupPhoto/SelectGroupPhotoView.swift
+++ b/Projects/Features/Scene/CreateGroupScene/SelectGroupPhoto/SelectGroupPhotoView.swift
@@ -21,7 +21,7 @@ public struct SelectGroupPhotoView: View {
   public var body: some View {
     VStack(spacing: 0) {
       NavigationBar(
-        type: .titleWithBackButton("그룹 만들기"),
+        type: .titleWithBackButton("그룹 만들기", .center),
         backButtonAction: { store.send(.backButtonTapped) }
       )
       

--- a/Projects/Features/Scene/CreateGroupScene/SelectKeyword/SelectKeywordView.swift
+++ b/Projects/Features/Scene/CreateGroupScene/SelectKeyword/SelectKeywordView.swift
@@ -21,7 +21,7 @@ public struct SelectKeywordView: View {
   public var body: some View {
     VStack(spacing: 0) {
       NavigationBar(
-        type: .titleWithBackButton("그룹 만들기"),
+        type: .titleWithBackButton("그룹 만들기", .center),
         backButtonAction: { store.send(.backButtonTapped) }
       )
       

--- a/Projects/Features/Scene/CreateGroupScene/SetGroupName/SetGroupNameView.swift
+++ b/Projects/Features/Scene/CreateGroupScene/SetGroupName/SetGroupNameView.swift
@@ -20,7 +20,7 @@ public struct SetGroupNameView: View {
   public var body: some View {
     VStack(spacing: 0) {
       NavigationBar(
-        type: .titleWithBackButton("그룹 만들기"),
+        type: .titleWithBackButton("그룹 만들기", .center),
         backButtonAction: { store.send(.backButtonTapped) }
       )
       

--- a/Projects/Features/Scene/LoginScene/Login/LoginCore.swift
+++ b/Projects/Features/Scene/LoginScene/Login/LoginCore.swift
@@ -22,15 +22,18 @@ public struct LoginCore {
     public var isPresented: Bool
     public var kakaoUser: KaKaoUserInfo
     public var kakaoIdToken: KakaoToken
+    @Shared var userInfo: UserInfo
     
     public init(
       isPresented: Bool = false,
       kakaoUser: KaKaoUserInfo = KaKaoUserInfo(),
-      kakaoIdToken: KakaoToken = KakaoToken()
+      kakaoIdToken: KakaoToken = KakaoToken(),
+      userInfo: @autoclosure () -> UserInfo = .defaultValue
     ) {
       self.isPresented = isPresented
       self.kakaoUser = kakaoUser
       self.kakaoIdToken = kakaoIdToken
+      self._userInfo = Shared(wrappedValue: userInfo(), .inMemory("userInfo"))
     }
   }
   
@@ -116,16 +119,16 @@ public struct LoginCore {
         }
         
       case let .loginResponse(.success(user)):
+        let userInfo = UserInfo(
+          userID: user.userID,
+          nickname: user.nickname,
+          accessToken: user.accessToken,
+          refreshToken: user.refreshToken
+        )
+        state.userInfo = userInfo
         return .run { send in
-          let userInfo = UserInfo(
-            userID: user.userID,
-            nickname: user.nickname,
-            accessToken: user.accessToken,
-            refreshToken: user.refreshToken
-          )
           await send(.saveUserInfoToKeychain(Result { try await self.keyChainClient.createUserInfo(userInfo) }))
           await send(.moveToHome)
-          // TODO: - Save UserInfo to SharedState
         }
         
       case .loginResponse(.failure):

--- a/Projects/Features/Scene/MainScene/GroupList/GroupListCore.swift
+++ b/Projects/Features/Scene/MainScene/GroupList/GroupListCore.swift
@@ -17,11 +17,14 @@ public struct GroupListCore {
   @ObservableState
   public struct State: Equatable {
     var groups: [GroupData]
+    @Shared var userInfo: UserInfo
     
     public init(
-      groups: [GroupData] = []
+      groups: [GroupData] = [],
+      userInfo: @autoclosure () -> UserInfo = .defaultValue
     ) {
       self.groups = groups
+      self._userInfo = Shared(wrappedValue: userInfo(), .inMemory("userInfo"))
     }
   }
 
@@ -50,10 +53,9 @@ public struct GroupListCore {
     Reduce { state, action in
       switch action {
       case .onAppear:
-        return .run (
-          operation: { send in
-            let userInfo = try await keyChainClient.readUserInfo()
-            await send(.getGroupsResponse(Result { try await self.groupAPIClient.getGroups(accessToken: userInfo.accessToken) }))
+        return .run(
+          operation: { [state] send in
+            await send(.getGroupsResponse(Result { try await self.groupAPIClient.getGroups(accessToken: state.userInfo.accessToken) }))
           },
           catch: { error, send in
           }

--- a/Projects/Features/Scene/MyPageScene/MyPage/MyPageView.swift
+++ b/Projects/Features/Scene/MyPageScene/MyPage/MyPageView.swift
@@ -21,7 +21,7 @@ public struct MyPageView: View {
   
   public var body: some View {
     VStack {
-      NavigationBar(type: .titleWithBackButton(MyPageNameSpace.myPageTitle))
+      NavigationBar(type: .titleWithBackButton(MyPageNameSpace.myPageTitle, .center))
       
       SettingTitleView(
         text: store.nickname,

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
-        "revision" : "9dc9cbe4bc45c65164fa653a563d8d8db61b09bb",
-        "version" : "1.0.0"
+        "revision" : "9fa31f4403da54855f1e2aeaeff478f4f0e40b13",
+        "version" : "1.0.2"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "8d712376c99fc0267aa0e41fea732babe365270a",
-        "version" : "1.3.3"
+        "revision" : "71344dd930fde41e8f3adafe260adcbb2fc2a3dc",
+        "version" : "1.5.4"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
-        "revision" : "a8421d68068d8f45fbceb418fbf22c5dad4afd33",
-        "version" : "1.0.2"
+        "revision" : "3581e280bf0d90c3fb9236fb23e75a5d8c46b533",
+        "version" : "1.0.4"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture.git",
       "state" : {
-        "revision" : "cf967a28a8605629559533320d604168d733fc9c",
-        "version" : "1.8.0"
+        "revision" : "8624a8e2c35f78e5e61d5f12c69110e9020e80c8",
+        "version" : "1.10.0"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "f01efb26f3a192a0e88dcdb7c3c391ec2fc25d9c",
-        "version" : "1.3.0"
+        "revision" : "aec6a73f5c1dc1f1be4f61888094b95cf995d973",
+        "version" : "1.3.2"
       }
     },
     {
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "350e1e119babe8525f9bd155b76640a5de270184",
-        "version" : "1.3.0"
+        "revision" : "cc26d06125dbc913c6d9e8a905a5db0b994509e0",
+        "version" : "1.3.5"
       }
     },
     {
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-identified-collections",
       "state" : {
-        "revision" : "d533cd18b0b456b106694a9899f917ee595f2666",
-        "version" : "1.0.2"
+        "revision" : "2f5ab6e091dd032b63dacbda052405756010dc3b",
+        "version" : "1.1.0"
       }
     },
     {
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-perception",
       "state" : {
-        "revision" : "8e8ca36c02abc7775a3ab81f9468c0df5fe22c2c",
-        "version" : "1.1.7"
+        "revision" : "1552c8f722ac256cc0b8daaf1a7073217d4fcdfb",
+        "version" : "1.3.4"
       }
     },
     {
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swiftui-navigation",
       "state" : {
-        "revision" : "2ec6c3a15293efff6083966b38439a4004f25565",
-        "version" : "1.3.0"
+        "revision" : "fc91d591ebba1f90d65028ccb65c861e5979e898",
+        "version" : "1.5.4"
       }
     },
     {
@@ -185,8 +185,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "6f30bdba373bbd7fbfe241dddd732651f2fbd1e2",
-        "version" : "1.1.2"
+        "revision" : "357ca1e5dd31f613a1d43320870ebc219386a495",
+        "version" : "1.2.2"
       }
     }
   ],

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -20,7 +20,7 @@ let packageSettings = PackageSettings(
 let package = Package(
   name: "Gabbangzip",
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-composable-architecture.git", exact: "1.8.0"),
+    .package(url: "https://github.com/pointfreeco/swift-composable-architecture.git", exact: "1.10.0"),
     .package(url: "https://github.com/johnpatrickmorgan/TCACoordinators", from: "0.10.0"),
     .package(url: "https://github.com/kean/Nuke.git", from: "12.0.0"),
     .package(url: "https://github.com/airbnb/lottie-ios.git", from: "4.4.3"),


### PR DESCRIPTION
## 📌 Related Issue
- #92 

## 🚀 Description
- TCA 1.10.0에 도입된 SharedState 적용

## ✅ Done
- [x] SharedState 적용
- [x] TCA 버전 업데이트(`1.8.0` -> `1.10.0`)

## 📸 Screenshot

## 📢 Notes
- 기존에는 API 요청 시 요청에 필요한 access token을 Keychain에서 가져오기 위해 매번 에러 처리를 수행했으나, 이제 Shared State를 사용함으로써 에러 처리 과정이 제거되어 API 요청에 대한 보일러플레이트 코드가 사라짐. 이에 코드 절감 효과가 상당할 것으로 예상됨(간결성⬆️, 생산성⬆️)
- Persisted shared state에 관한 문서는 [이곳](https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/sharingstate#Persisted-shared-state)에서 확인할 수 있습니다
 
## 🧪 Testing(optional)
