### PR TITLE
[Feat] 홈 화면 리팩토링 및 API연동

### DIFF
--- a/Projects/Core/Models/Group/Response/GroupData.swift
+++ b/Projects/Core/Models/Group/Response/GroupData.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct GroupData: Decodable, Hashable {
+public struct GroupData: Decodable, Equatable {
   public let id: Int
   public let name: String
   public let keyword: Keyword
@@ -27,7 +27,7 @@ public struct GroupData: Decodable, Hashable {
   }
 }
 
-public struct RecentEvent: Decodable, Hashable {
+public struct RecentEvent: Decodable, Equatable {
   public let id: Int
   public let name: String?
   public let date: String?

--- a/Projects/Core/Models/Group/Response/GroupData.swift
+++ b/Projects/Core/Models/Group/Response/GroupData.swift
@@ -28,8 +28,19 @@ public struct GroupData: Decodable, Hashable {
 }
 
 public struct RecentEvent: Decodable, Hashable {
+  public let id: Int
   public let name: String?
   public let date: String?
+  
+  public init(
+    id: Int,
+    name: String?,
+    date: String?
+  ) {
+    self.id = id
+    self.name = name
+    self.date = date
+  }
 }
 
 extension GroupData {

--- a/Projects/Core/Models/Group/Response/GroupsData.swift
+++ b/Projects/Core/Models/Group/Response/GroupsData.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct GroupsData: Decodable, Equatable {
+public struct GroupsData: Decodable {
   public let groups: [GroupData]
 }
 

--- a/Projects/Core/Models/Group/Response/GroupsData.swift
+++ b/Projects/Core/Models/Group/Response/GroupsData.swift
@@ -21,7 +21,7 @@ extension GroupsData {
         keyword: .school,
         status: .noPastAndCurrentEvent,
         statusDescription: "최근 업데이트 2일전",
-        recentEvent: .init(name: nil, date: nil),
+        recentEvent: .init(id: 0, name: nil, date: nil),
         cardFrontImageURL: "https://picsum.photos/200",
         cardBackImages: [
           CardBackImage(
@@ -36,7 +36,7 @@ extension GroupsData {
         keyword: .company,
         status: .beforeMyVote,
         statusDescription: "최근 업데이트 3일전",
-        recentEvent: .init(name: "이벤트", date: "2024-07-03T01:22:28.673Z"),
+        recentEvent: .init(id: 1, name: "이벤트", date: "2024-07-03T01:22:28.673Z"),
         cardFrontImageURL: "https://picsum.photos/200",
         cardBackImages: [
           CardBackImage(
@@ -51,7 +51,7 @@ extension GroupsData {
         keyword: .crew,
         status: .afterMyVote,
         statusDescription: "최근 업데이트 1일전",
-        recentEvent: .init(name: "이벤트", date: "2024-07-03T01:22:28.673Z"),
+        recentEvent: .init(id: 2, name: "이벤트", date: "2024-07-03T01:22:28.673Z"),
         cardFrontImageURL: "https://picsum.photos/200",
         cardBackImages: [
           CardBackImage(
@@ -66,7 +66,7 @@ extension GroupsData {
         keyword: .exercise,
         status: .beforeMyUpload,
         statusDescription: "최근 업데이트 23432일전",
-        recentEvent: .init(name: "이벤트", date: "2024-07-03T01:22:28.673Z"),
+        recentEvent: .init(id: 3, name: "이벤트", date: "2024-07-03T01:22:28.673Z"),
         cardFrontImageURL: "https://picsum.photos/200",
         cardBackImages: [
           CardBackImage(
@@ -81,7 +81,7 @@ extension GroupsData {
         keyword: .network,
         status: .afterMyUpload,
         statusDescription: "최근 업데이트 2232일전",
-        recentEvent: .init(name: "이벤트", date: "2024-07-03T01:22:28.673Z"),
+        recentEvent: .init(id: 4, name: "이벤트", date: "2024-07-03T01:22:28.673Z"),
         cardFrontImageURL: "https://picsum.photos/200",
         cardBackImages: [
           CardBackImage(
@@ -96,7 +96,7 @@ extension GroupsData {
         keyword: .school,
         status: .noCurrentEvent,
         statusDescription: "최근 업데이트 21일전",
-        recentEvent: .init(name: "이벤트", date: "2024-07-03T01:22:28.673Z"),
+        recentEvent: .init(id: 5, name: "이벤트", date: "2024-07-03T01:22:28.673Z"),
         cardFrontImageURL: "https://picsum.photos/200",
         cardBackImages: [
           CardBackImage(
@@ -123,7 +123,7 @@ extension GroupsData {
         keyword: .school,
         status: .eventCompleted,
         statusDescription: "최근 업데이트 44일전",
-        recentEvent: .init(name: "이벤트", date: "2024-07-03T01:22:28.673Z"),
+        recentEvent: .init(id: 6, name: "이벤트", date: "2024-07-03T01:22:28.673Z"),
         cardFrontImageURL: "https://picsum.photos/200",
         cardBackImages: [
           CardBackImage(

--- a/Projects/Core/Models/PushNotification/Response/Kook.swift
+++ b/Projects/Core/Models/PushNotification/Response/Kook.swift
@@ -1,0 +1,21 @@
+//
+//  Kook.swift
+//  Models
+//
+//  Created by YangJoonHyeok on 8/8/24.
+//  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
+//
+
+import Foundation
+
+public struct Kook: Codable {
+  public let eventID: Int
+  
+  enum CodingKeys: String, CodingKey {
+    case eventID = "event_id"
+  }
+}
+
+extension Kook {
+  public static let mock = Self(eventID: 0)
+}

--- a/Projects/Core/Models/PushNotification/Response/KookInfo.swift
+++ b/Projects/Core/Models/PushNotification/Response/KookInfo.swift
@@ -1,5 +1,5 @@
 //
-//  Kook.swift
+//  KookInfo.swift
 //  Models
 //
 //  Created by YangJoonHyeok on 8/8/24.
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct Kook: Codable {
+public struct KookInfo: Decodable {
   public let eventID: Int
   
   enum CodingKeys: String, CodingKey {
@@ -16,6 +16,6 @@ public struct Kook: Codable {
   }
 }
 
-extension Kook {
+extension KookInfo {
   public static let mock = Self(eventID: 0)
 }

--- a/Projects/Core/Models/PushNotification/Response/RegisteredFCMToken.swift
+++ b/Projects/Core/Models/PushNotification/Response/RegisteredFCMToken.swift
@@ -1,0 +1,21 @@
+//
+//  RegisteredFCMToken.swift
+//  Models
+//
+//  Created by YangJoonHyeok on 8/8/24.
+//  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
+//
+
+import Foundation
+
+public struct RegisteredFCMToken: Decodable {
+  public let registedToken: String
+  
+  enum CodingKeys: String, CodingKey {
+    case registedToken = "registed_token"
+  }
+}
+
+extension RegisteredFCMToken {
+  public static let mock = Self(registedToken: "")
+}

--- a/Projects/Core/Services/PicAPIClients/PushNotificationAPI/PushNotificationAPI.swift
+++ b/Projects/Core/Services/PicAPIClients/PushNotificationAPI/PushNotificationAPI.swift
@@ -1,0 +1,61 @@
+//
+//  PushNotificationAPI.swift
+//  Services
+//
+//  Created by YangJoonHyeok on 8/8/24.
+//  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
+//
+
+import Foundation
+import Get
+
+public enum PushNotificationAPI {
+  case registerFCMToken(accessToken: String, fcmToken: String)
+  case kook(accessToken: String, eventID: Int)
+}
+
+extension PushNotificationAPI: RouteType {
+  public var path: String {
+    switch self {
+    case .registerFCMToken:
+      return "/api/v1/alarm/token"
+    case .kook:
+      return "/api/v1/alarm/kook"
+    }
+  }
+  
+  public var method: HTTPMethod {
+    switch self {
+    case .registerFCMToken:
+      return .post
+    case .kook:
+      return .post
+    }
+  }
+  
+  public var query: [(String, String?)]? {
+    switch self {
+    case .registerFCMToken:
+      return nil
+    case .kook:
+      return nil
+    }
+  }
+  
+  public var body: Encodable? {
+    switch self {
+    case let .registerFCMToken(_, fcmToken):
+      return ["token": fcmToken]
+    case let .kook(_, eventID):
+      return ["event_id": eventID]
+    }
+  }
+  
+  public var headers: [String: String]? {
+    switch self {
+    case let .registerFCMToken(accessToken, _), let .kook(accessToken, _):
+      return ["Authorization": "Bearer \(accessToken)"]
+    }
+  }
+}
+

--- a/Projects/Core/Services/PicAPIClients/PushNotificationAPI/PushNotificationAPIClient.swift
+++ b/Projects/Core/Services/PicAPIClients/PushNotificationAPI/PushNotificationAPIClient.swift
@@ -13,7 +13,7 @@ import Models
 @DependencyClient
 public struct PushNotificationAPIClient: Sendable {
   public var registerFCMToken: (_ accessToken: String, _ fcmToken: String) async throws -> RegisteredFCMToken
-  public var kook: (_ accessToken: String, _ eventID: Int) async throws -> Kook
+  public var kook: (_ accessToken: String, _ eventID: Int) async throws -> KookInfo
 }
 
 extension PushNotificationAPIClient: DependencyKey {
@@ -35,7 +35,7 @@ extension PushNotificationAPIClient: DependencyKey {
       },
       kook: { accessToken, eventID in
         let route = PushNotificationAPI.kook(accessToken: accessToken, eventID: eventID)
-        let request = Request<SuccessResponse<Kook>>(route: route)
+        let request = Request<SuccessResponse<KookInfo>>(route: route)
         
         do {
           let response = try await NetworkManager.shared.send(request)
@@ -60,7 +60,7 @@ extension PushNotificationAPIClient: DependencyKey {
         return RegisteredFCMToken.mock
       },
       kook: { _, _ in
-        return Kook.mock
+        return KookInfo.mock
       }
     )
   }

--- a/Projects/Core/Services/PicAPIClients/PushNotificationAPI/PushNotificationAPIClient.swift
+++ b/Projects/Core/Services/PicAPIClients/PushNotificationAPI/PushNotificationAPIClient.swift
@@ -1,0 +1,94 @@
+//
+//  PushNotificationAPIClient.swift
+//  Services
+//
+//  Created by YangJoonHyeok on 8/8/24.
+//  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
+//
+
+import ComposableArchitecture
+import Get
+import Models
+
+@DependencyClient
+public struct PushNotificationAPIClient: Sendable {
+  public var registerFCMToken: (_ accessToken: String, _ fcmToken: String) async throws -> RegisteredFCMToken
+  public var kook: (_ accessToken: String, _ eventID: Int) async throws -> Kook
+}
+
+extension PushNotificationAPIClient: DependencyKey {
+  public static var liveValue: PushNotificationAPIClient {
+    return PushNotificationAPIClient(
+      registerFCMToken: { accessToken, fcmToken in
+        let route = PushNotificationAPI.registerFCMToken(accessToken: accessToken, fcmToken: fcmToken)
+        let request = Request<SuccessResponse<RegisteredFCMToken>>(route: route)
+        
+        do {
+          let response = try await NetworkManager.shared.send(request)
+          return response.value.data
+        } catch {
+          throw PushNotificationAPIClientError(
+            code: .getAPIError,
+            underlying: error
+          )
+        }
+      },
+      kook: { accessToken, eventID in
+        let route = PushNotificationAPI.kook(accessToken: accessToken, eventID: eventID)
+        let request = Request<SuccessResponse<Kook>>(route: route)
+        
+        do {
+          let response = try await NetworkManager.shared.send(request)
+          return response.value.data
+        } catch {
+          throw PushNotificationAPIClientError(
+            code: .getAPIError,
+            underlying: error
+          )
+        }
+      }
+    )
+  }
+  
+  public static var testValue: PushNotificationAPIClient {
+    return PushNotificationAPIClient()
+  }
+  
+  public static var previewValue: PushNotificationAPIClient {
+    return PushNotificationAPIClient(
+      registerFCMToken: { _, _ in
+        return RegisteredFCMToken.mock
+      },
+      kook: { _, _ in
+        return Kook.mock
+      }
+    )
+  }
+}
+
+extension DependencyValues {
+  public var pushNotificationAPIClient: PushNotificationAPIClient {
+    get { self[PushNotificationAPIClient.self] }
+    set { self[PushNotificationAPIClient.self] = newValue }
+  }
+}
+
+public struct PushNotificationAPIClientError: GabbangzipError {
+  public var userInfo: [String: Any]
+  public var code: APIResponseError
+  public var underlying: Error?
+
+  public init(
+    userInfo: [String: Any] = [:],
+    code: APIResponseError,
+    underlying: Error? = nil
+  ) {
+    self.userInfo = userInfo
+    self.code = code
+    self.underlying = underlying
+  }
+
+  public enum APIResponseError: Int {
+    case getAPIError = 0
+  }
+}

--- a/Projects/Core/Services/PicAPIClients/PushNotificationAPI/PushNotificationAPIClient.swift
+++ b/Projects/Core/Services/PicAPIClients/PushNotificationAPI/PushNotificationAPIClient.swift
@@ -89,6 +89,6 @@ public struct PushNotificationAPIClientError: GabbangzipError {
   }
 
   public enum APIResponseError: Int {
-    case getAPIError = 0
+    case getAPIError
   }
 }

--- a/Projects/DesignSystem/Sources/Views/Toast/ToastType.swift
+++ b/Projects/DesignSystem/Sources/Views/Toast/ToastType.swift
@@ -8,7 +8,7 @@
 
 import SwiftUI
 
-public enum ToastType {
+public enum ToastType: Equatable {
   case onlyText(String)
   case textWithCheckIcon(String)
   case textWithInfoIcon(String)

--- a/Projects/Features/Scene/CreateGroupScene/CreateGroupCompletion/CreateGroupCompletionView.swift
+++ b/Projects/Features/Scene/CreateGroupScene/CreateGroupCompletion/CreateGroupCompletionView.swift
@@ -11,6 +11,7 @@ import DesignSystem
 import Models
 import NukeUI
 import SwiftUI
+import Lovebug
 
 public struct CreateGroupCompletionView: View {
   @Bindable var store: StoreOf<CreateGroupCompletionCore>
@@ -37,12 +38,12 @@ public struct CreateGroupCompletionView: View {
           Tag(type: store.createdGroupInfo.keyword.tagType)
           
           PhotoWithFrame(
-            frame: store.createdGroupInfo.keyword.frame,
-            backgroundColor: store.createdGroupInfo.keyword.backgroundColor,
-            imageURLString: store.createdGroupInfo.groupImageURL,
-            isBackgroundClear: false
+            keyword: store.createdGroupInfo.keyword,
+            foregroundColor: store.createdGroupInfo.keyword.foregroundColor,
+            imageURLString: store.imageURLString
           )
           .padding(.init(top: 24, leading: 30, bottom: 26, trailing: 30))
+            
           
           Text(store.createdGroupInfo.groupName)
             .font(.head20)

--- a/Projects/Features/Scene/CreateGroupScene/CreateGroupCompletion/CreateGroupCompletionView.swift
+++ b/Projects/Features/Scene/CreateGroupScene/CreateGroupCompletion/CreateGroupCompletionView.swift
@@ -8,10 +8,10 @@
 
 import ComposableArchitecture
 import DesignSystem
+import Lovebug
 import Models
 import NukeUI
 import SwiftUI
-import Lovebug
 
 public struct CreateGroupCompletionView: View {
   @Bindable var store: StoreOf<CreateGroupCompletionCore>
@@ -38,7 +38,7 @@ public struct CreateGroupCompletionView: View {
           Tag(type: store.createdGroupInfo.keyword.tagType)
           
           PhotoWithFrame(
-            keyword: store.createdGroupInfo.keyword,
+            frameShape: store.createdGroupInfo.keyword.frame,
             foregroundColor: store.createdGroupInfo.keyword.foregroundColor,
             imageURLString: store.imageURLString
           )

--- a/Projects/Features/Scene/CreateGroupScene/SelectGroupPhoto/SelectGroupPhotoCore.swift
+++ b/Projects/Features/Scene/CreateGroupScene/SelectGroupPhoto/SelectGroupPhotoCore.swift
@@ -24,7 +24,6 @@ public struct SelectGroupPhotoCore {
     var keyword: GroupData.Keyword
     var nextButtonType: ButtonType
     var selectedPhotosInfo: [PhotoInfo]
-    var fileExtension: String = ""
 
     public init(
       userInfo: @autoclosure () -> UserInfo = .defaultValue,
@@ -32,8 +31,7 @@ public struct SelectGroupPhotoCore {
       groupName: String,
       keyword: GroupData.Keyword,
       nextButtonType: ButtonType = .inactive,
-      selectedPhotosInfo: [PhotoInfo] = [],
-      fileExtension: String = ""
+      selectedPhotosInfo: [PhotoInfo] = []
     ) {
       self._userInfo = Shared(wrappedValue: userInfo(), .inMemory("userInfo"))
       self._isGroupListUpdated = Shared(wrappedValue: isGroupListUpdated(), .inMemory("isGroupListUpdated"))
@@ -41,7 +39,6 @@ public struct SelectGroupPhotoCore {
       self.nextButtonType = nextButtonType
       self.keyword = keyword
       self.selectedPhotosInfo = selectedPhotosInfo
-      self.fileExtension = fileExtension
     }
   }
 

--- a/Projects/Features/Scene/GroupDetailScene/Vote/VoteComplete/VoteCompleteView.swift
+++ b/Projects/Features/Scene/GroupDetailScene/Vote/VoteComplete/VoteCompleteView.swift
@@ -8,6 +8,7 @@
 
 import ComposableArchitecture
 import DesignSystem
+import Lovebug
 import Models
 import SwiftUI
 

--- a/Projects/Features/Scene/Lovebug/Frame+extensions.swift
+++ b/Projects/Features/Scene/Lovebug/Frame+extensions.swift
@@ -1,0 +1,32 @@
+//
+//  Frame+extensions.swift
+//  Lovebug
+//
+//  Created by YangJoonHyeok on 8/11/24.
+//  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
+//
+
+import DesignSystem
+import Models
+import SwiftUI
+
+public extension CardBackImage.Frame {
+  var image: Image {
+    switch self {
+    case .snowman:
+      return DesignSystem.Icons.snowmanFrame
+    case .ghost:
+      return DesignSystem.Icons.ghostFrame
+    case .hamburger:
+      return DesignSystem.Icons.hamburgerFrame
+    case .plus:
+      return DesignSystem.Icons.plusFrame
+    case .sexy:
+      return DesignSystem.Icons.sexyFrame
+    case .flower:
+      return DesignSystem.Icons.flowerFrame
+    case .clover:
+      return DesignSystem.Icons.cloverFrame
+    }
+  }
+}

--- a/Projects/Features/Scene/Lovebug/GroupDataStatus+extensions.swift
+++ b/Projects/Features/Scene/Lovebug/GroupDataStatus+extensions.swift
@@ -1,0 +1,25 @@
+//
+//  GroupDataStatus+extensions.swift
+//  Util
+//
+//  Created by YangJoonHyeok on 8/8/24.
+//  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
+//
+
+import DesignSystem
+import Models
+
+public extension GroupData.Status {
+  var smallButtonContentType: SmallButtonContentType? {
+    switch self {
+    case .beforeMyUpload:
+      return .gallery
+    case .afterMyUpload, .afterMyVote:
+      return .stabbing
+    case .beforeMyVote:
+      return .vote
+    default:
+      return nil
+    }
+  }
+}

--- a/Projects/Features/Scene/Lovebug/GroupDataStatus+extensions.swift
+++ b/Projects/Features/Scene/Lovebug/GroupDataStatus+extensions.swift
@@ -1,6 +1,6 @@
 //
 //  GroupDataStatus+extensions.swift
-//  Util
+//  Lovebug
 //
 //  Created by YangJoonHyeok on 8/8/24.
 //  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.

--- a/Projects/Features/Scene/Lovebug/Keyword+extensions.swift
+++ b/Projects/Features/Scene/Lovebug/Keyword+extensions.swift
@@ -1,6 +1,6 @@
 //
 //  Keyword+extensions.swift
-//  CreateGroup
+//  Lovebug
 //
 //  Created by YangJoonHyeok on 7/9/24.
 //  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.

--- a/Projects/Features/Scene/Lovebug/Keyword+extensions.swift
+++ b/Projects/Features/Scene/Lovebug/Keyword+extensions.swift
@@ -6,11 +6,12 @@
 //  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
 //
 
+import DesignSystem
 import Models
 import SwiftUI
 
-extension GroupData.Keyword {
-  public var categoryType: CategoryType {
+public extension GroupData.Keyword {
+  var categoryType: CategoryType {
     switch self {
     case .school:
       return .school
@@ -29,7 +30,7 @@ extension GroupData.Keyword {
     }
   }
   
-  public var tagType: TagType {
+  var tagType: TagType {
     switch self {
     case .school:
       return .category(.school)
@@ -48,7 +49,7 @@ extension GroupData.Keyword {
     }
   }
   
-  public var frame: Image {
+  var frame: Image {
     switch self {
     case .school:
       return DesignSystem.Icons.snowmanFrame
@@ -67,7 +68,7 @@ extension GroupData.Keyword {
     }
   }
   
-  public var backgroundColor: Color {
+  var backgroundColor: Color {
     switch self {
     case .school:
       return DesignSystem.Colors.conifer20
@@ -86,7 +87,7 @@ extension GroupData.Keyword {
     }
   }
   
-  public var foregroundColor: Color {
+  var foregroundColor: Color {
     switch self {
     case .school:
       return DesignSystem.Colors.conifer30
@@ -105,7 +106,7 @@ extension GroupData.Keyword {
     }
   }
   
-  public func convertToPhotoCardStatus<T: View>() -> PhotoCard<T>.Status {
+  func convertToPhotoCardStatus<T: View>() -> PhotoCard<T>.Status {
     switch self {
     case .school:
       return .school

--- a/Projects/Features/Scene/Lovebug/PhotoWithFrame.swift
+++ b/Projects/Features/Scene/Lovebug/PhotoWithFrame.swift
@@ -1,0 +1,60 @@
+//
+//  PhotoWithFrame.swift
+//  Util
+//
+//  Created by YangJoonHyeok on 8/8/24.
+//  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
+//
+
+import Models
+import NukeUI
+import SwiftUI
+
+public struct PhotoWithFrame: View {
+  public let keyword: GroupData.Keyword
+  public let foregroundColor: Color
+  public let imageURLString: String
+
+  public init(
+    keyword: GroupData.Keyword,
+    foregroundColor: Color,
+    imageURLString: String
+  ) {
+    self.keyword = keyword
+    self.foregroundColor = foregroundColor
+    self.imageURLString = imageURLString
+  }
+
+  public var body: some View {
+    keyword.frame
+      .resizable()
+      .aspectRatio(contentMode: .fit)
+      .foregroundStyle(foregroundColor)
+      .background {
+        LazyImage(url: URL(string: imageURLString)) { state in
+          if let image = state.image {
+            image
+              .resizable()
+              .aspectRatio(contentMode: .fill)
+          }
+        }
+      }
+      .clipped()
+  }
+}
+
+#Preview {
+  Group {
+    PhotoWithFrame(
+      keyword: .company, 
+      foregroundColor: GroupData.Keyword.company.foregroundColor,
+      imageURLString: "https://24ai.tech/ru/wp-content/uploads/sites/4/2023/10/01_product_1_sdelat-kvadratnym-scaled.jpg"
+    )
+
+    PhotoWithFrame(
+      keyword: .company,
+      foregroundColor: GroupData.Keyword.company.foregroundColor,
+      imageURLString: "https://24ai.tech/ru/wp-content/uploads/sites/4/2023/10/01_product_1_sdelat-kvadratnym-scaled.jpg"
+    )
+  }
+}

--- a/Projects/Features/Scene/Lovebug/PhotoWithFrame.swift
+++ b/Projects/Features/Scene/Lovebug/PhotoWithFrame.swift
@@ -11,22 +11,22 @@ import NukeUI
 import SwiftUI
 
 public struct PhotoWithFrame: View {
-  public let keyword: GroupData.Keyword
+  public let frameShape: Image
   public let foregroundColor: Color
   public let imageURLString: String
 
   public init(
-    keyword: GroupData.Keyword,
+    frameShape: Image,
     foregroundColor: Color,
     imageURLString: String
   ) {
-    self.keyword = keyword
+    self.frameShape = frameShape
     self.foregroundColor = foregroundColor
     self.imageURLString = imageURLString
   }
 
   public var body: some View {
-    keyword.frame
+    frameShape
       .resizable()
       .aspectRatio(contentMode: .fit)
       .foregroundStyle(foregroundColor)
@@ -46,13 +46,13 @@ public struct PhotoWithFrame: View {
 #Preview {
   Group {
     PhotoWithFrame(
-      keyword: .company, 
+      frameShape: GroupData.Keyword.company.frame,
       foregroundColor: GroupData.Keyword.company.foregroundColor,
       imageURLString: "https://24ai.tech/ru/wp-content/uploads/sites/4/2023/10/01_product_1_sdelat-kvadratnym-scaled.jpg"
     )
 
     PhotoWithFrame(
-      keyword: .company,
+      frameShape: GroupData.Keyword.company.frame,
       foregroundColor: GroupData.Keyword.company.foregroundColor,
       imageURLString: "https://24ai.tech/ru/wp-content/uploads/sites/4/2023/10/01_product_1_sdelat-kvadratnym-scaled.jpg"
     )

--- a/Projects/Features/Scene/Lovebug/PhotoWithFrame.swift
+++ b/Projects/Features/Scene/Lovebug/PhotoWithFrame.swift
@@ -1,6 +1,6 @@
 //
 //  PhotoWithFrame.swift
-//  Util
+//  Lovebug
 //
 //  Created by YangJoonHyeok on 8/8/24.
 //  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.

--- a/Projects/Features/Scene/MainScene/Group/GroupCore.swift
+++ b/Projects/Features/Scene/MainScene/Group/GroupCore.swift
@@ -1,0 +1,182 @@
+//
+//  GroupCore.swift
+//  Main
+//
+//  Created by YangJoonHyeok on 8/8/24.
+//  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
+//
+
+import Common
+import ComposableArchitecture
+import DesignSystem
+import Models
+
+@Reducer
+public struct GroupCore {
+  public init() {}
+
+  @ObservableState
+  public struct State: Equatable, Identifiable {
+    @Shared var userInfo: UserInfo
+    public var id: Int
+    var name: String
+    var keyword: GroupData.Keyword
+    var status: GroupData.Status
+    var statusDescription: String
+    var recentEvent: RecentEvent
+    var cardFrontImageURL: String
+    var cardBackImages: [CardBackImage]?
+    var isLast: Bool
+    var s3BucketDomain: String
+    var selectedPhotosInfo: [PhotoInfo]
+    var stabbingButtonType: SmallButtonType
+
+    public init(
+      userInfo: Shared<UserInfo>,
+      id: Int,
+      name: String,
+      keyword: GroupData.Keyword,
+      status: GroupData.Status,
+      statusDescription: String,
+      recentEvent: RecentEvent,
+      cardFrontImageURL: String,
+      cardBackImages: [CardBackImage]?,
+      isLast: Bool,
+      s3BucketDomain: String = "",
+      selectedPhotosInfo: [PhotoInfo] = [],
+      stabbingButtonType: SmallButtonType = .active
+    ) {
+      self._userInfo = userInfo
+      self.id = id
+      self.name = name
+      self.keyword = keyword
+      self.status = status
+      self.statusDescription = statusDescription
+      self.recentEvent = recentEvent
+      self.cardFrontImageURL = cardFrontImageURL
+      self.cardBackImages = cardBackImages
+      self.isLast = isLast
+      self.s3BucketDomain = s3BucketDomain
+      self.selectedPhotosInfo = selectedPhotosInfo
+      self.stabbingButtonType = stabbingButtonType
+    }
+  }
+
+  public enum Action {
+    // Delegate Action
+    case delegate(Delegate)
+    
+    // View Action
+    case headerButtonTapped
+    case createEventButtonTapped
+    case stabbingButtonTapped
+    case selectPICButtonTapped
+    case selectedPhotosInfo([PhotoInfo])
+    
+    // Internal Action
+    case kookResponse(Result<Kook, Error>)
+    case getUploadURLResponse(Result<FileUploadInfo, Error>, PhotoInfo)
+    case uploadFileToPresignedURLResponse(Result<Void, Error>)
+    
+    public enum Delegate {
+      case headerButtonTapped
+      case createEventButtonTapped
+      case stabbingSuccessed
+      case stabbingFailed
+      case imageUploadSuccessed
+      case imageUploadFailed
+      case selectPICButtonTapped
+    }
+  }
+  
+  @Dependency(\.pushNotificationAPIClient) var pushNotificationAPIClient
+  @Dependency(\.fileUploadAPIClient) var fileUploadAPIClient
+
+  public var body: some Reducer<State, Action> {
+    Reduce { state, action in
+      switch action {
+      case .delegate:
+        return .none
+        
+      case .headerButtonTapped:
+        return .send(.delegate(.headerButtonTapped))
+        
+      case .createEventButtonTapped:
+        return .send(.delegate(.createEventButtonTapped))
+        
+      case .stabbingButtonTapped:
+        return .run { [state] send in
+          await send(.kookResponse(Result {
+            try await self.pushNotificationAPIClient.kook(
+              accessToken: state.userInfo.accessToken,
+              eventID: state.recentEvent.id
+            )
+          }))
+        }
+        
+      case .selectPICButtonTapped:
+        return .send(.delegate(.selectPICButtonTapped))
+        
+      case let .selectedPhotosInfo(photosInfo):
+        return .run { [state] send in
+          if !photosInfo.isEmpty {
+            let photoInfo = photosInfo[0]
+            await send(
+              .getUploadURLResponse(
+                Result {
+                  try await self.fileUploadAPIClient.getUploadURL(
+                    accessToken: state.userInfo.accessToken,
+                    fileExtension: photoInfo.fileExtension
+                  )
+                },
+                photoInfo
+              )
+            )
+          }
+        }
+        
+      case .kookResponse(.success):
+        state.stabbingButtonType = .inactive
+        return .send(.delegate(.stabbingSuccessed))
+        
+      case let .kookResponse(.failure(error)):
+        return .run { send in
+          logger.error(error.localizedDescription)
+          await send(.delegate(.stabbingFailed))
+        }
+        
+      case let .getUploadURLResponse(.success(fileUploadInfo), photoInfo):
+        return .run { send in
+          await send(
+            .uploadFileToPresignedURLResponse(
+              Result {
+                try await self.fileUploadAPIClient.uploadFile(
+                  uploadURL: fileUploadInfo.uploadURL,
+                  data: photoInfo.data,
+                  fileExtension: photoInfo.fileExtension
+                )
+              }
+            )
+          )
+        }
+        
+      case let .getUploadURLResponse(.failure(error), _):
+        return .run { send in
+          logger.error(error.localizedDescription)
+          await send(.delegate(.imageUploadFailed))
+        }
+        
+      case .uploadFileToPresignedURLResponse(.success):
+        return .run { send in
+          await send(.delegate(.imageUploadSuccessed))
+        }
+        
+      case let .uploadFileToPresignedURLResponse(.failure(error)):
+        return .run { send in
+          logger.error(error.localizedDescription)
+          await send(.delegate(.imageUploadFailed))
+        }
+      }
+    }
+  }
+}

--- a/Projects/Features/Scene/MainScene/Group/GroupCore.swift
+++ b/Projects/Features/Scene/MainScene/Group/GroupCore.swift
@@ -30,6 +30,9 @@ public struct GroupCore {
     var s3BucketDomain: String
     var selectedPhotosInfo: [PhotoInfo]
     var stabbingButtonType: SmallButtonType
+    var hasNoEvent: Bool {
+      return status == .noPastAndCurrentEvent || status == .noCurrentEvent
+    }
 
     public init(
       userInfo: Shared<UserInfo>,

--- a/Projects/Features/Scene/MainScene/Group/GroupCore.swift
+++ b/Projects/Features/Scene/MainScene/Group/GroupCore.swift
@@ -77,7 +77,7 @@ public struct GroupCore {
     case selectedPhotosInfo([PhotoInfo])
     
     // Internal Action
-    case kookResponse(Result<Kook, Error>)
+    case kookResponse(Result<KookInfo, Error>)
     case getUploadURLResponse(Result<FileUploadInfo, Error>, PhotoInfo)
     case uploadFileToPresignedURLResponse(Result<Void, Error>)
     

--- a/Projects/Features/Scene/MainScene/Group/GroupCore.swift
+++ b/Projects/Features/Scene/MainScene/Group/GroupCore.swift
@@ -33,6 +33,18 @@ public struct GroupCore {
     var hasNoEvent: Bool {
       return status == .noPastAndCurrentEvent || status == .noCurrentEvent
     }
+    var hasCompletedEvent: Bool {
+      return status == .noCurrentEvent || status == .eventCompleted
+    }
+    var recentEventDate: String {
+      return recentEvent.date?.toGroupEventDateString() ?? ""
+    }
+    var recentEventName: String {
+      return recentEvent.name ?? ""
+    }
+    var frontTitle: String {
+      return status == .noPastAndCurrentEvent ? "이벤트를 만들어 보세요!" : recentEventDate
+    }
 
     public init(
       userInfo: Shared<UserInfo>,

--- a/Projects/Features/Scene/MainScene/Group/GroupView.swift
+++ b/Projects/Features/Scene/MainScene/Group/GroupView.swift
@@ -15,10 +15,6 @@ import SwiftUI
 
 public struct GroupView: View {
   @Bindable var store: StoreOf<GroupCore>
-  private let columns = [
-    GridItem(.flexible(), spacing: 9),
-    GridItem(.flexible(), spacing: 9)
-  ]
   
   public init(store: StoreOf<GroupCore>) {
     self.store = store
@@ -37,12 +33,14 @@ public struct GroupView: View {
 
       HStack {
         Tag(type: store.keyword.tagType)
+        
         Tag(type: .etc(.custom(store.statusDescription)))
+        
         Spacer(minLength: 0)
       }
       .padding(.horizontal, 16)
       
-      groupContentView()
+      GroupContentView(store: store)
       
       if !store.isLast {
         Divider()
@@ -50,122 +48,6 @@ public struct GroupView: View {
           .overlay(DesignSystem.Colors.gray20)
           .padding(.top, 8)
       }
-    }
-  }
-}
-
-extension GroupView {
-  private func groupContentView() -> some View {
-    VStack(spacing: 16) {
-      if store.status == .noCurrentEvent || store.status == .eventCompleted {
-        FlipView(
-          frontContent: {
-            PhotoCard(status: store.keyword.convertToPhotoCardStatus()) {
-              photoCardFrontView()
-            }
-          },
-          backContent: {
-            PhotoCard(status: store.keyword.convertToPhotoCardStatus()) {
-              photoCardBackView()
-            }
-          }
-        )
-        .padding(.horizontal, 41.5)
-      } else {
-        PhotoCard(status: store.keyword.convertToPhotoCardStatus()) {
-          VStack(spacing: 16) {
-            photoCardFrontView()
-            
-            if store.status == .noPastAndCurrentEvent {
-              SmallButton(
-                type: .active,
-                smallButtonContentType: .generateEvent,
-                action: { store.send(.createEventButtonTapped) }
-              )
-            }
-          }
-        }
-        .padding(.horizontal, 41.5)
-        
-        if let buttonType = store.status.smallButtonContentType {
-          switch store.status {
-          case .beforeMyUpload:
-            GabbangzipPhotoPicker(
-              selectedPhotosInfo: $store.selectedPhotosInfo.sending(\.selectedPhotosInfo),
-              maxSelectedCount: .custom(4),
-              matching: .images,
-              content: {
-                SmallButton(
-                  type: .active,
-                  smallButtonContentType: buttonType,
-                  action: {}
-                )
-                .disabled(true)
-              }
-            )
-          case .afterMyUpload, .afterMyVote:
-            SmallButton(
-              type: store.stabbingButtonType,
-              smallButtonContentType: buttonType,
-              action: { store.send(.stabbingButtonTapped) }
-            )
-          case .beforeMyVote:
-            SmallButton(
-              type: .active,
-              smallButtonContentType: buttonType,
-              action: { store.send(.selectPICButtonTapped) }
-            )
-          default:
-            EmptyView()
-          }
-        }
-      }
-    }
-  }
-  
-  private func photoCardFrontView() -> some View {
-    VStack(spacing: 16) {
-      Text(
-        store.status == .noPastAndCurrentEvent
-        ? "이벤트를 만들어 보세요!"
-        : store.recentEvent.date?.toGroupEventDateString() ?? ""
-      )
-      .font(.body16)
-      .foregroundStyle(DesignSystem.Colors.gray80)
-      
-      PhotoWithFrame(
-        keyword: store.keyword,
-        foregroundColor: store.keyword.foregroundColor,
-        imageURLString: store.s3BucketDomain + store.cardFrontImageURL
-      )
-      .padding(.horizontal, 30)
-      
-      Text(store.recentEvent.name ?? "")
-        .font(.head20)
-        .foregroundStyle(DesignSystem.Colors.gray80)
-    }
-  }
-  
-  private func photoCardBackView() -> some View {
-    VStack(spacing: 16) {
-      Text(store.recentEvent.date?.toGroupEventDateString() ?? "")
-        .font(.body16)
-        .foregroundStyle(DesignSystem.Colors.gray80)
-      
-      LazyVGrid(columns: columns, spacing: 9) {
-        ForEach(store.cardBackImages ?? [], id: \.self) { card in
-          PhotoWithFrame(
-            keyword: store.keyword,
-            foregroundColor: store.keyword.foregroundColor,
-            imageURLString: store.s3BucketDomain + store.cardFrontImageURL
-          )
-        }
-      }
-      .padding(.horizontal, 20)
-      
-      Text(store.recentEvent.name ?? "")
-        .font(.head20)
-        .foregroundStyle(DesignSystem.Colors.gray80)
     }
   }
 }

--- a/Projects/Features/Scene/MainScene/Group/GroupView.swift
+++ b/Projects/Features/Scene/MainScene/Group/GroupView.swift
@@ -8,10 +8,10 @@
 
 import ComposableArchitecture
 import DesignSystem
+import Lovebug
 import Models
 import NukeUI
 import SwiftUI
-import Lovebug
 
 public struct GroupView: View {
   @Bindable var store: StoreOf<GroupCore>
@@ -26,7 +26,7 @@ public struct GroupView: View {
   
   public var body: some View {
     VStack(spacing: 16) {
-      if store.status == .noPastAndCurrentEvent || store.status == .noCurrentEvent {
+      if store.hasNoEvent {
         GroupHeaderView(title: "이벤트를 만들어 보세요!", isButtonStyle: false)
       } else {
         Button(

--- a/Projects/Features/Scene/MainScene/Group/GroupView.swift
+++ b/Projects/Features/Scene/MainScene/Group/GroupView.swift
@@ -55,7 +55,6 @@ public struct GroupView: View {
 }
 
 extension GroupView {
-  @MainActor
   private func groupContentView() -> some View {
     VStack(spacing: 16) {
       if store.status == .noCurrentEvent || store.status == .eventCompleted {
@@ -124,7 +123,6 @@ extension GroupView {
     }
   }
   
-  @MainActor
   private func photoCardFrontView() -> some View {
     VStack(spacing: 16) {
       Text(
@@ -148,7 +146,6 @@ extension GroupView {
     }
   }
   
-  @MainActor
   private func photoCardBackView() -> some View {
     VStack(spacing: 16) {
       Text(store.recentEvent.date?.toGroupEventDateString() ?? "")

--- a/Projects/Features/Scene/MainScene/Group/GroupView.swift
+++ b/Projects/Features/Scene/MainScene/Group/GroupView.swift
@@ -1,0 +1,203 @@
+//
+//  GroupView.swift
+//  Main
+//
+//  Created by YangJoonHyeok on 8/8/24.
+//  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
+//
+
+import ComposableArchitecture
+import DesignSystem
+import Models
+import NukeUI
+import SwiftUI
+import Lovebug
+
+public struct GroupView: View {
+  @Bindable var store: StoreOf<GroupCore>
+  private let columns = [
+    GridItem(.flexible(), spacing: 9),
+    GridItem(.flexible(), spacing: 9)
+  ]
+  
+  public init(store: StoreOf<GroupCore>) {
+    self.store = store
+  }
+  
+  public var body: some View {
+    VStack(spacing: 16) {
+      if store.status == .noPastAndCurrentEvent || store.status == .noCurrentEvent {
+        GroupHeaderView(title: "이벤트를 만들어 보세요!", isButtonStyle: false)
+      } else {
+        Button(
+          action: { store.send(.headerButtonTapped) },
+          label: { GroupHeaderView(title: store.name, isButtonStyle: true) }
+        )
+      }
+
+      HStack {
+        Tag(type: store.keyword.tagType)
+        Tag(type: .etc(.custom(store.statusDescription)))
+        Spacer(minLength: 0)
+      }
+      .padding(.horizontal, 16)
+      
+      groupContentView()
+      
+      if !store.isLast {
+        Divider()
+          .frame(height: 8)
+          .overlay(DesignSystem.Colors.gray20)
+          .padding(.top, 8)
+      }
+    }
+  }
+}
+
+extension GroupView {
+  @MainActor
+  private func groupContentView() -> some View {
+    VStack(spacing: 16) {
+      if store.status == .noCurrentEvent || store.status == .eventCompleted {
+        FlipView(
+          frontContent: {
+            PhotoCard(status: store.keyword.convertToPhotoCardStatus()) {
+              photoCardFrontView()
+            }
+          },
+          backContent: {
+            PhotoCard(status: store.keyword.convertToPhotoCardStatus()) {
+              photoCardBackView()
+            }
+          }
+        )
+        .padding(.horizontal, 41.5)
+      } else {
+        PhotoCard(status: store.keyword.convertToPhotoCardStatus()) {
+          VStack(spacing: 16) {
+            photoCardFrontView()
+            
+            if store.status == .noPastAndCurrentEvent {
+              SmallButton(
+                type: .active,
+                smallButtonContentType: .generateEvent,
+                action: { store.send(.createEventButtonTapped) }
+              )
+            }
+          }
+        }
+        .padding(.horizontal, 41.5)
+        
+        if let buttonType = store.status.smallButtonContentType {
+          switch store.status {
+          case .beforeMyUpload:
+            GabbangzipPhotoPicker(
+              selectedPhotosInfo: $store.selectedPhotosInfo.sending(\.selectedPhotosInfo),
+              maxSelectedCount: .custom(4),
+              matching: .images,
+              content: {
+                SmallButton(
+                  type: .active,
+                  smallButtonContentType: buttonType,
+                  action: {}
+                )
+                .disabled(true)
+              }
+            )
+          case .afterMyUpload, .afterMyVote:
+            SmallButton(
+              type: store.stabbingButtonType,
+              smallButtonContentType: buttonType,
+              action: { store.send(.stabbingButtonTapped) }
+            )
+          case .beforeMyVote:
+            SmallButton(
+              type: .active,
+              smallButtonContentType: buttonType,
+              action: { store.send(.selectPICButtonTapped) }
+            )
+          default:
+            EmptyView()
+          }
+        }
+      }
+    }
+  }
+  
+  @MainActor
+  private func photoCardFrontView() -> some View {
+    VStack(spacing: 16) {
+      Text(
+        store.status == .noPastAndCurrentEvent
+        ? "이벤트를 만들어 보세요!"
+        : store.recentEvent.date?.toGroupEventDateString() ?? ""
+      )
+      .font(.body16)
+      .foregroundStyle(DesignSystem.Colors.gray80)
+      
+      PhotoWithFrame(
+        keyword: store.keyword,
+        foregroundColor: store.keyword.foregroundColor,
+        imageURLString: store.s3BucketDomain + store.cardFrontImageURL
+      )
+      .padding(.horizontal, 30)
+      
+      Text(store.recentEvent.name ?? "")
+        .font(.head20)
+        .foregroundStyle(DesignSystem.Colors.gray80)
+    }
+  }
+  
+  @MainActor
+  private func photoCardBackView() -> some View {
+    VStack(spacing: 16) {
+      Text(store.recentEvent.date?.toGroupEventDateString() ?? "")
+        .font(.body16)
+        .foregroundStyle(DesignSystem.Colors.gray80)
+      
+      LazyVGrid(columns: columns, spacing: 9) {
+        ForEach(store.cardBackImages ?? [], id: \.self) { card in
+          PhotoWithFrame(
+            keyword: store.keyword,
+            foregroundColor: store.keyword.foregroundColor,
+            imageURLString: store.s3BucketDomain + store.cardFrontImageURL
+          )
+        }
+      }
+      .padding(.horizontal, 20)
+      
+      Text(store.recentEvent.name ?? "")
+        .font(.head20)
+        .foregroundStyle(DesignSystem.Colors.gray80)
+    }
+  }
+}
+
+#Preview {
+  GroupView(
+    store: Store(
+      initialState: .init(
+        userInfo: Shared<UserInfo>.init(UserInfo(
+          userID: 1,
+          nickname: "james",
+          accessToken: "",
+          refreshToken: ""
+        )),
+        id: 0,
+        name: "test",
+        keyword: GroupData.Keyword.company,
+        status: GroupData.Status.eventCompleted,
+        statusDescription: "hi",
+        recentEvent: RecentEvent(
+          id: 0, 
+          name: "hi",
+          date: "2024-07-05T00:00:00Z"
+        ),
+        cardFrontImageURL: "",
+        cardBackImages: nil,
+        isLast: false
+      ),
+      reducer: GroupCore.init
+    )
+  )
+}

--- a/Projects/Features/Scene/MainScene/Group/Views/GroupContentView.swift
+++ b/Projects/Features/Scene/MainScene/Group/Views/GroupContentView.swift
@@ -1,0 +1,103 @@
+//
+//  GroupContentView.swift
+//  Main
+//
+//  Created by YangJoonHyeok on 8/11/24.
+//  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
+//
+
+import ComposableArchitecture
+import DesignSystem
+import SwiftUI
+
+struct GroupContentView: View {
+  @Bindable var store: StoreOf<GroupCore>
+  
+  init(store: StoreOf<GroupCore>) {
+    self.store = store
+  }
+  
+  var body: some View {
+    VStack(spacing: 16) {
+      if store.hasCompletedEvent {
+        FlipView(
+          frontContent: {
+            PhotoCard(status: store.keyword.convertToPhotoCardStatus()) {
+              PhotoCardFrontView(
+                title: store.frontTitle,
+                keyword: store.keyword,
+                imageURLString: store.s3BucketDomain + store.cardFrontImageURL,
+                recentEventName: store.recentEventName
+              )
+            }
+          },
+          backContent: {
+            PhotoCard(status: store.keyword.convertToPhotoCardStatus()) {
+              PhotoCardBackView(
+                recentEventData: store.recentEventDate,
+                cardBackImages: store.cardBackImages ?? [],
+                recentEventName: store.recentEventName,
+                foregroundColor: store.keyword.foregroundColor,
+                s3BucketDomain: store.s3BucketDomain
+              )
+            }
+          }
+        )
+        .padding(.horizontal, 41.5)
+      } else {
+        PhotoCard(status: store.keyword.convertToPhotoCardStatus()) {
+          VStack(spacing: 16) {
+            PhotoCardFrontView(
+              title: store.frontTitle,
+              keyword: store.keyword,
+              imageURLString: store.s3BucketDomain + store.cardFrontImageURL,
+              recentEventName: store.recentEventName
+            )
+            
+            if store.status == .noPastAndCurrentEvent {
+              SmallButton(
+                type: .active,
+                smallButtonContentType: .generateEvent,
+                action: { store.send(.createEventButtonTapped) }
+              )
+            }
+          }
+        }
+        .padding(.horizontal, 41.5)
+        
+        if let buttonType = store.status.smallButtonContentType {
+          switch store.status {
+          case .beforeMyUpload:
+            GabbangzipPhotoPicker(
+              selectedPhotosInfo: $store.selectedPhotosInfo.sending(\.selectedPhotosInfo),
+              maxSelectedCount: .custom(4),
+              matching: .images,
+              content: {
+                SmallButton(
+                  type: .active,
+                  smallButtonContentType: buttonType,
+                  action: {}
+                )
+                .disabled(true)
+              }
+            )
+          case .afterMyUpload, .afterMyVote:
+            SmallButton(
+              type: store.stabbingButtonType,
+              smallButtonContentType: buttonType,
+              action: { store.send(.stabbingButtonTapped) }
+            )
+          case .beforeMyVote:
+            SmallButton(
+              type: .active,
+              smallButtonContentType: buttonType,
+              action: { store.send(.selectPICButtonTapped) }
+            )
+          default:
+            EmptyView()
+          }
+        }
+      }
+    }
+  }
+}

--- a/Projects/Features/Scene/MainScene/Group/Views/GroupHeaderView.swift
+++ b/Projects/Features/Scene/MainScene/Group/Views/GroupHeaderView.swift
@@ -1,0 +1,44 @@
+//
+//  GroupHeaderView.swift
+//  Main
+//
+//  Created by YangJoonHyeok on 8/8/24.
+//  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
+//
+
+import DesignSystem
+import SwiftUI
+
+struct GroupHeaderView: View {
+  var title: String
+  var isButtonStyle: Bool
+  
+  init(title: String, isButtonStyle: Bool) {
+    self.title = title
+    self.isButtonStyle = isButtonStyle
+  }
+  
+  var body: some View {
+    HStack {
+      Text(title)
+        .font(.head24)
+        .foregroundStyle(Color(DesignSystem.Colors.gray80))
+        .frame(maxWidth: .infinity, alignment: .leading)
+      
+      Spacer()
+      
+      if isButtonStyle {
+        DesignSystem.Icons.rightArrow
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+          .frame(width: 26, height: 26)
+      }
+    }
+    .padding(.horizontal, 16)
+    .padding(.top, 14)
+  }
+}
+
+#Preview {
+  GroupHeaderView(title: "이벤트를 만들어 보세요!", isButtonStyle: false)
+}

--- a/Projects/Features/Scene/MainScene/Group/Views/PhotoCardBackView.swift
+++ b/Projects/Features/Scene/MainScene/Group/Views/PhotoCardBackView.swift
@@ -1,0 +1,72 @@
+//
+//  PhotoCardBackView.swift
+//  Main
+//
+//  Created by YangJoonHyeok on 8/11/24.
+//  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
+//
+
+import DesignSystem
+import Lovebug
+import Models
+import SwiftUI
+
+struct PhotoCardBackView: View {
+  var recentEventData: String
+  var cardBackImages: [CardBackImage]
+  var recentEventName: String
+  var foregroundColor: Color
+  var s3BucketDomain: String
+  
+  private let columns = [
+    GridItem(.flexible(), spacing: 9),
+    GridItem(.flexible(), spacing: 9)
+  ]
+  
+  init(
+    recentEventData: String,
+    cardBackImages: [CardBackImage],
+    recentEventName: String,
+    foregroundColor: Color,
+    s3BucketDomain: String
+  ) {
+    self.recentEventData = recentEventData
+    self.cardBackImages = cardBackImages
+    self.recentEventName = recentEventName
+    self.foregroundColor = foregroundColor
+    self.s3BucketDomain = s3BucketDomain
+  }
+  
+  var body: some View {
+    VStack(spacing: 16) {
+      Text(recentEventData)
+        .font(.body16)
+        .foregroundStyle(DesignSystem.Colors.gray80)
+      
+      LazyVGrid(columns: columns, spacing: 9) {
+        ForEach(cardBackImages, id: \.self) { card in
+          PhotoWithFrame(
+            frameShape: card.frame.image,
+            foregroundColor: foregroundColor,
+            imageURLString: s3BucketDomain + card.imageURL
+          )
+        }
+      }
+      .padding(.horizontal, 20)
+      
+      Text(recentEventName)
+        .font(.head20)
+        .foregroundStyle(DesignSystem.Colors.gray80)
+    }
+  }
+}
+
+#Preview {
+  PhotoCardBackView(
+    recentEventData: "2024-07-05T00:00:00Z",
+    cardBackImages: [],
+    recentEventName: "우리의 믿음",
+    foregroundColor: DesignSystem.Colors.conifer30,
+    s3BucketDomain: ""
+  )
+}

--- a/Projects/Features/Scene/MainScene/Group/Views/PhotoCardFrontView.swift
+++ b/Projects/Features/Scene/MainScene/Group/Views/PhotoCardFrontView.swift
@@ -1,0 +1,58 @@
+//
+//  PhotoCardFrontView.swift
+//  Main
+//
+//  Created by YangJoonHyeok on 8/11/24.
+//  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
+//
+
+import DesignSystem
+import Lovebug
+import Models
+import SwiftUI
+
+struct PhotoCardFrontView: View {
+  var title: String
+  var keyword: GroupData.Keyword
+  var imageURLString: String
+  var recentEventName: String
+  
+  init(
+    title: String,
+    keyword: GroupData.Keyword,
+    imageURLString: String,
+    recentEventName: String
+  ) {
+    self.title = title
+    self.keyword = keyword
+    self.imageURLString = imageURLString
+    self.recentEventName = recentEventName
+  }
+  
+  var body: some View {
+    VStack(spacing: 16) {
+      Text(title)
+      .font(.body16)
+      .foregroundStyle(DesignSystem.Colors.gray80)
+      
+      PhotoWithFrame(
+        frameShape: keyword.frame,
+        foregroundColor: keyword.foregroundColor,
+        imageURLString: imageURLString
+      )
+      .padding(.horizontal, 30)
+      
+      Text(recentEventName)
+        .font(.head20)
+        .foregroundStyle(DesignSystem.Colors.gray80)
+    }
+  }
+}
+#Preview {
+  PhotoCardFrontView(
+    title: "2023년 8월 11일",
+    keyword: .company,
+    imageURLString: "",
+    recentEventName: "축하해"
+  )
+}

--- a/Projects/Features/Scene/MainScene/GroupList/GroupListCore.swift
+++ b/Projects/Features/Scene/MainScene/GroupList/GroupListCore.swift
@@ -9,6 +9,7 @@
 import ComposableArchitecture
 import Models
 import Services
+import DesignSystem
 
 @Reducer
 public struct GroupListCore {
@@ -16,51 +17,56 @@ public struct GroupListCore {
   
   @ObservableState
   public struct State: Equatable {
-    var groups: [GroupData]
+    var groups: IdentifiedArrayOf<GroupCore.State>
     @Shared var userInfo: UserInfo
     @Shared var isGroupListUpdated: Bool
-    var s3BucketDomain: String
     var floatingButtonExpanded: Bool
+    var toastPresented: Bool
+    var toastType: ToastType
     
     public init(
-      groups: [GroupData] = [],
+      groups: IdentifiedArrayOf<GroupCore.State> = [],
       userInfo: @autoclosure () -> UserInfo = .defaultValue,
       isGroupListUpdated: @autoclosure () -> Bool = false,
-      s3BucketDomain: String = "",
-      floatingButtonExpanded: Bool = false
+      floatingButtonExpanded: Bool = false,
+      toastPresented: Bool = false,
+      toastType: ToastType = .onlyText("")
     ) {
       self.groups = groups
       self._userInfo = Shared(wrappedValue: userInfo(), .inMemory("userInfo"))
       self._isGroupListUpdated = Shared(wrappedValue: isGroupListUpdated(), .inMemory("isGroupListUpdated"))
-      self.s3BucketDomain = s3BucketDomain
       self.floatingButtonExpanded = floatingButtonExpanded
+      self.toastPresented = toastPresented
+      self.toastType = toastType
     }
   }
 
   public enum Action {
     // View Action
     case onAppear
-    case createEventButtonTapped
-    case picButtonTapped
-    case nudgeButtonTapped
-    case voteButtonTapped
-    case groupHeaderButtonTapped
     case joinGroupButtonTapped
     case createGroupButtonTapped
     case myPageButtonTapped
+    case toastPresentedChanged(Bool)
     
     // Internal Action
     case fetchGroups
     case getGroupsResponse(Result<GroupsData, Error>)
     case getS3BucketDomain(Result<String?, Error>)
-    case setS3BucketDomain(String)
     case floatingButtonExpandedChanged(Bool)
     case isGroupListUpdatedChanged(Bool)
+    case showToastMessage(ToastType)
+    
+    // Child Action
+    case groups(IdentifiedActionOf<GroupCore>)
     
     // Route Action
     case moveToMyPage
     case moveToCreateGroup
     case moveToJoinGroup
+    case moveToGroupDetail
+    case moveToCreateEvent
+    case moveToVote
   }
   
   @Dependency(\.groupAPIClient) var groupAPIClient
@@ -79,21 +85,6 @@ public struct GroupListCore {
           }
         ])
         
-      case .createEventButtonTapped:
-        return .none
-        
-      case .picButtonTapped:
-        return .none
-        
-      case .nudgeButtonTapped:
-        return .none
-        
-      case .voteButtonTapped:
-        return .none
-        
-      case .groupHeaderButtonTapped:
-        return .none
-        
       case .joinGroupButtonTapped:
         state.floatingButtonExpanded = false
         return .send(.moveToJoinGroup)
@@ -105,23 +96,40 @@ public struct GroupListCore {
       case .myPageButtonTapped:
         return .send(.moveToMyPage)
         
+      case let .toastPresentedChanged(value):
+        state.toastPresented = value
+        return .none
+        
       case .fetchGroups:
         state.isGroupListUpdated = false
-        return .run(
-          operation: { [state] send in
-            await send(.getGroupsResponse(Result {
-              try await self.groupAPIClient.getGroups(accessToken: state.userInfo.accessToken)
-            }))
-            await send(.getS3BucketDomain(Result {
-              try bundleClient.getValue(key: "S3BucketDomain") as? String
-            }))
-          },
-          catch: { error, send in
-          }
-        )
+        return .run { [state] send in
+          await send(.getGroupsResponse(Result {
+            try await self.groupAPIClient.getGroups(state.userInfo.accessToken)
+          }))
+          await send(.getS3BucketDomain(Result {
+            try bundleClient.getValue("S3BucketDomain") as? String
+          }))
+        }
         
       case let .getGroupsResponse(.success(groupsData)):
-        state.groups = groupsData.groups
+        state.groups = IdentifiedArray(
+          uniqueElements: groupsData.groups
+            .enumerated()
+            .map { index, group in
+              GroupCore.State(
+                userInfo: state.$userInfo,
+                id: group.id,
+                name: group.name,
+                keyword: group.keyword,
+                status: group.status,
+                statusDescription: group.statusDescription,
+                recentEvent: group.recentEvent,
+                cardFrontImageURL: group.cardFrontImageURL,
+                cardBackImages: group.cardBackImages,
+                isLast: index == groupsData.groups.count - 1
+              )
+            }
+        )
         return .none
         
       case .getGroupsResponse(.failure):
@@ -130,15 +138,13 @@ public struct GroupListCore {
         
       case let .getS3BucketDomain(.success(domain)):
         if let domain {
-          state.s3BucketDomain = domain
+          for i in 0..<state.groups.count {
+            state.groups[i].s3BucketDomain = domain
+          }
         }
         return .none
         
       case .getS3BucketDomain(.failure):
-        return .none
-        
-      case let .setS3BucketDomain(domain):
-        state.s3BucketDomain = domain
         return .none
         
       case let .floatingButtonExpandedChanged(value):
@@ -152,6 +158,35 @@ public struct GroupListCore {
           }
         }
         
+      case let .showToastMessage(toastType):
+        state.toastType = toastType
+        state.toastPresented = true
+        return .none
+        
+      case let .groups(.element(id: _, action: .delegate(delegate))):
+        return .run { send in
+          switch delegate {
+          case .headerButtonTapped:
+            await send(.moveToGroupDetail)
+          case .createEventButtonTapped:
+            await send(.moveToCreateEvent)
+          case .stabbingSuccessed:
+            await send(.showToastMessage(.textWithCheckIcon("쿡찌르기 성공!")))
+          case .stabbingFailed:
+            await send(.showToastMessage(.textWithInfoIcon("쿡찌르기 실패!")))
+          case .imageUploadSuccessed:
+            await send(.showToastMessage(.textWithCheckIcon("이미지 업로드 성공!")))
+            await send(.fetchGroups)
+          case .imageUploadFailed:
+            await send(.showToastMessage(.textWithInfoIcon("이미지 업로드 실패!")))
+          case .selectPICButtonTapped:
+            await send(.moveToVote)
+          }
+        }
+        
+      case .groups:
+        return .none
+        
       case .moveToMyPage:
         return .none
         
@@ -160,7 +195,19 @@ public struct GroupListCore {
         
       case .moveToJoinGroup:
         return .none
+        
+      case .moveToGroupDetail:
+        return .none
+        
+      case .moveToCreateEvent:
+        return .none
+        
+      case .moveToVote:
+        return .none
       }
+    }
+    .forEach(\.groups, action: \.groups) {
+      GroupCore()
     }
   }
 }

--- a/Projects/Features/Scene/MainScene/GroupList/GroupListCore.swift
+++ b/Projects/Features/Scene/MainScene/GroupList/GroupListCore.swift
@@ -7,9 +7,9 @@
 //
 
 import ComposableArchitecture
+import DesignSystem
 import Models
 import Services
-import DesignSystem
 
 @Reducer
 public struct GroupListCore {

--- a/Projects/Features/Scene/MainScene/GroupList/GroupListCore.swift
+++ b/Projects/Features/Scene/MainScene/GroupList/GroupListCore.swift
@@ -138,7 +138,7 @@ public struct GroupListCore {
         
       case let .getS3BucketDomain(.success(domain)):
         if let domain {
-          for i in 0..<state.groups.count {
+          for i in state.groups.indices {
             state.groups[i].s3BucketDomain = domain
           }
         }

--- a/Projects/Features/Scene/MainScene/GroupList/GroupListView.swift
+++ b/Projects/Features/Scene/MainScene/GroupList/GroupListView.swift
@@ -14,10 +14,6 @@ import SwiftUI
 
 public struct GroupListView: View {
   @Bindable var store: StoreOf<GroupListCore>
-  private let columns = [
-    GridItem(.flexible(), spacing: 9),
-    GridItem(.flexible(), spacing: 9)
-  ]
 
   public init(store: StoreOf<GroupListCore>) {
     self.store = store
@@ -32,51 +28,18 @@ public struct GroupListView: View {
       
       ScrollView {
         LazyVStack {
-          ForEach(Array(store.groups.enumerated()), id: \.element) { index, group in
-            VStack(spacing: 16) {
-              Button(
-                action: { store.send(.groupHeaderButtonTapped) },
-                label: {
-                  HStack {
-                    Text(group.name)
-                      .font(.head24)
-                      .foregroundStyle(Color(DesignSystem.Colors.gray80))
-                      .frame(maxWidth: .infinity, alignment: .leading)
-                    
-                    Spacer()
-                    
-                    DesignSystem.Icons.rightArrow
-                      .resizable()
-                      .aspectRatio(contentMode: .fit)
-                      .frame(width: 26, height: 26)
-                  }
-                  .padding(.horizontal, 16)
-                  .padding(.top, 14)
-                }
-              )
-              
-              HStack {
-                createTag(from: group.keyword)
-                Tag(type: .etc(.custom(group.statusDescription)))
-                Spacer(minLength: 0)
-              }
-              .padding(.horizontal, 16)
-              
-              groupContentView(group: group)
-              
-              if store.groups.count - 1 != index {
-                Divider()
-                  .frame(height: 8)
-                  .overlay(DesignSystem.Colors.gray20)
-                  .padding(.top, 8)
-              }
-            }
+          ForEach(store.scope(state: \.groups, action: \.groups)) { childStore in
+            GroupView(store: childStore)
           }
         }
       }
     }
     .background(DesignSystem.Colors.gray0)
     .onAppear { store.send(.onAppear) }
+    .toast(
+      isPresented: $store.toastPresented.sending(\.toastPresentedChanged),
+      type: store.toastType
+    )
     .overlay(alignment: .bottomTrailing) {
       FloatingButton(isExpanded: $store.floatingButtonExpanded.sending(\.floatingButtonExpandedChanged)) {
         FloatingOptionButton(
@@ -93,221 +56,6 @@ public struct GroupListView: View {
       }
       .padding(.trailing, 16)
       .padding(.bottom, 24)
-    }
-  }
-}
-
-extension GroupListView {
-  @MainActor
-  private func groupContentView(group: GroupData) -> some View {
-    VStack(spacing: 16) {
-      if group.status == .noCurrentEvent || group.status == .eventCompleted {
-        FlipView(
-          frontContent: {
-            PhotoCard(status: mapStatus(from: group.keyword)) {
-              photoCardFrontView(from: group)
-            }
-          },
-          backContent: {
-            PhotoCard(status: mapStatus(from: group.keyword)) {
-              photoCardBackView(from: group)
-            }
-          }
-        )
-        .padding(.horizontal, 41.5)
-      } else {
-        PhotoCard(status: mapStatus(from: group.keyword)) {
-          VStack(spacing: 16) {
-            photoCardFrontView(from: group)
-            
-            if group.status == .noPastAndCurrentEvent {
-              SmallButton(type: .active, smallButtonContentType: .generateEvent, action: {})
-            }
-          }
-        }
-        .padding(.horizontal, 41.5)
-        
-        if let buttonType = mapButtonType(from: group.status) {
-          SmallButton(type: .active, smallButtonContentType: buttonType, action: {})
-        }
-      }
-    }
-  }
-  
-  @MainActor
-  private func photoCardFrontView(from group: GroupData) -> some View {
-    VStack(spacing: 16) {
-      Text(
-        group.status == .noPastAndCurrentEvent
-        ? "이벤트를 만들어 보세요!"
-        : group.recentEvent.date?.toGroupEventDateString() ?? ""
-      )
-      .font(.body16)
-      .foregroundStyle(DesignSystem.Colors.gray80)
-      
-      photoInFrame(for: group.keyword, with: group.cardFrontImageURL)
-      .padding(.horizontal, 30)
-      
-      Text("이벤트명입니다")
-        .font(.head20)
-        .foregroundStyle(DesignSystem.Colors.gray80)
-    }
-  }
-  
-  @MainActor
-  private func photoCardBackView(from group: GroupData) -> some View {
-    VStack(spacing: 16) {
-      Text(group.recentEvent.date?.toGroupEventDateString() ?? "")
-        .font(.body16)
-        .foregroundStyle(DesignSystem.Colors.gray80)
-      
-      LazyVGrid(columns: columns, spacing: 9) {
-        ForEach(group.cardBackImages ?? [], id: \.self) { card in
-          photoInFrame(
-            for: mapKeyword(from: card.frame),
-            with: card.imageURL,
-            color: mapColor(from: group.keyword)
-          )
-        }
-      }
-      .padding(.horizontal, 20)
-      
-      Text("이벤트명입니다")
-        .font(.head20)
-        .foregroundStyle(DesignSystem.Colors.gray80)
-    }
-  }
-  
-  @MainActor
-  private func photoInFrame(
-    for keyword: GroupData.Keyword,
-    with image: String,
-    color: Color? = nil
-  ) -> some View {
-    let resolvedColor = color ?? mapColor(from: keyword)
-    let icon = mapIcon(for: keyword)
-    
-    return icon
-      .resizable()
-      .aspectRatio(contentMode: .fit)
-      .foregroundStyle(resolvedColor)
-      .background {
-        LazyImage(url: URL(string: store.s3BucketDomain + image)) { state in
-          if let image = state.image {
-            image
-              .resizable()
-              .aspectRatio(contentMode: .fill)
-          }
-        }
-      }
-      .clipped()
-  }
-  
-  private func mapStatus<T: View>(from keyword: GroupData.Keyword) -> PhotoCard<T>.Status {
-    switch keyword {
-    case .school:
-      return .school
-    case .company:
-      return .company
-    case .crew:
-      return .crew
-    case .network:
-      return .network
-    case .exercise:
-      return .exercise
-    case .hobby:
-      return .hobby
-    case .littleMoim:
-      return .littleMoim
-    }
-  }
-  
-  private func mapKeyword(from frame: CardBackImage.Frame) -> GroupData.Keyword {
-    switch frame {
-    case .snowman:
-      return .school
-    case .plus:
-      return .network
-    case .ghost:
-      return .company
-    case .clover:
-      return .littleMoim
-    case .sexy:
-      return .exercise
-    case .flower:
-      return .hobby
-    case .hamburger:
-      return .crew
-    }
-  }
-  
-  private func mapColor(from keyword: GroupData.Keyword) -> Color {
-    switch keyword {
-    case .school:
-      return DesignSystem.Colors.conifer30
-    case .company:
-      return DesignSystem.Colors.magentaPink30
-    case .crew: 
-      return DesignSystem.Colors.mayaBlue30
-    case .network:
-      return DesignSystem.Colors.coral30
-    case .exercise:
-      return DesignSystem.Colors.dandelion30
-    case .hobby:
-      return DesignSystem.Colors.malibu30
-    case .littleMoim:
-      return DesignSystem.Colors.lavender30
-    }
-  }
-  
-  private func createTag(from keyword: GroupData.Keyword) -> some View {
-    switch keyword {
-    case .school:
-      return Tag(type: .category(.school))
-    case .company:
-      return Tag(type: .category(.company))
-    case .crew:
-      return Tag(type: .category(.crew))
-    case .network:
-      return Tag(type: .category(.network))
-    case .exercise:
-      return Tag(type: .category(.exercise))
-    case .hobby:
-      return Tag(type: .category(.hobby))
-    case .littleMoim:
-      return Tag(type: .category(.littleMoim))
-    }
-  }
-  
-  private func mapIcon(for keyword: GroupData.Keyword) -> Image {
-    switch keyword {
-    case .school:
-      return DesignSystem.Icons.snowmanFrame
-    case .company:
-      return DesignSystem.Icons.ghostFrame
-    case .crew: 
-      return DesignSystem.Icons.hamburgerFrame
-    case .network:
-      return DesignSystem.Icons.plusFrame
-    case .exercise:
-      return DesignSystem.Icons.sexyFrame
-    case .hobby:
-      return DesignSystem.Icons.flowerFrame
-    case .littleMoim:
-      return DesignSystem.Icons.cloverFrame
-    }
-  }
-  
-  private func mapButtonType(from status: GroupData.Status) -> SmallButtonContentType? {
-    switch status {
-    case .beforeMyUpload:
-      return .uploadPIC
-    case .afterMyUpload, .afterMyVote:
-      return .stabbing
-    case .beforeMyVote:
-      return .vote
-    default:
-      return nil
     }
   }
 }

--- a/Projects/Features/Scene/Project.swift
+++ b/Projects/Features/Scene/Project.swift
@@ -12,6 +12,7 @@ let project = Project.make(
       dependencies: [
         .project(target: .coreKit, projectPath: .core),
         .project(target: .designSystem, projectPath: .designSystem),
+        .project(target: .lovebug, projectPath: .scene),
         .external(externalDependency: .composableArchitecture),
         .external(externalDependency: .nukeUI),
         .external(externalDependency: .lottie)
@@ -38,6 +39,7 @@ let project = Project.make(
         .project(target: .models, projectPath: .core),
         .project(target: .coreKit, projectPath: .core),
         .project(target: .designSystem, projectPath: .designSystem),
+        .project(target: .lovebug, projectPath: .scene),
         .external(externalDependency: .composableArchitecture),
         .external(externalDependency: .nukeUI),
         .external(externalDependency: .lottie)
@@ -64,9 +66,21 @@ let project = Project.make(
       dependencies: [
         .project(target: .coreKit, projectPath: .core),
         .project(target: .designSystem, projectPath: .designSystem),
+        .project(target: .lovebug, projectPath: .scene),
         .external(externalDependency: .composableArchitecture),
         .external(externalDependency: .nukeUI),
         .external(externalDependency: .lottie),
+      ]
+    ),
+    .make(
+      name: "Lovebug",
+      product: .framework,
+      bundleId: "com.mashup.gabbangzip.lovebug",
+      sources: ["Lovebug/**"],
+      dependencies: [
+        .project(target: .models, projectPath: .core),
+        .project(target: .designSystem, projectPath: .designSystem),
+        .external(externalDependency: .nukeUI)
       ]
     )
   ]

--- a/Tuist/ProjectDescriptionHelpers/TargetDependency+extensions.swift
+++ b/Tuist/ProjectDescriptionHelpers/TargetDependency+extensions.swift
@@ -43,6 +43,7 @@ public enum TargetName: String {
   case groupDetail = "GroupDetail"
   case myPage = "MyPage"
   case createGroup = "CreateGroup"
+  case lovebug = "Lovebug"
   case appCoordinator = "AppCoordinator"
   case mainCoordinator = "MainCoordinator"
   case createGroupCoordinator = "CreateGroupCoordinator"


### PR DESCRIPTION
## 📌 Related Issue
- #111 

## 🚀 Description
- 홈 화면의 그룹들을 ChildReducer로 구현하고 쿡찌르기, 이미지 업로드 API 연동
- 독립적인 Model과 DesignSystem을 Scene에서 재사용성과 편의성을 높여 사용하기 위해 새로운 타겟 생성

## ✅ TODO
- [x] 홈 화면 리팩토링
- [x] 이미지 업로드 API 연동
- [x] 쿡찌르기 API 연동
- [x] 러브버그 타겟 생성

## 📸 Screenshot(optional)

## 📢 Notes
 
## 🧪 Testing(optional)
