### PR TITLE
[Feat] 그룹 상세 API 연동 2탄

### DIFF
--- a/Projects/Core/Models/Group/Response/GroupDetailInfo.swift
+++ b/Projects/Core/Models/Group/Response/GroupDetailInfo.swift
@@ -109,43 +109,47 @@ public struct History: Decodable, Identifiable, Equatable {
       id: 0,
       name: "모임 이름1",
       date: "2024.06.01",
-      images: [.mock]
+      images: [
+        .init(
+          imageURL: "https://picsum.photos/200",
+          frame: .snowman
+        ),
+        .init(
+          imageURL: "https://picsum.photos/201",
+          frame: .snowman
+        ),
+        .init(
+          imageURL: "https://picsum.photos/202",
+          frame: .snowman
+        ),
+        .init(
+          imageURL: "https://picsum.photos/203",
+          frame: .snowman
+        )
+      ]
     ),
     .init(
       id: 1,
-      name: "모임 이름1",
+      name: "모임 이름2",
       date: "2024.06.01",
-      images: [.mock]
-    ),
-    .init(
-      id: 2,
-      name: "모임 이름1",
-      date: "2024.06.01",
-      images: [.mock]
-    ),
-    .init(
-      id: 3,
-      name: "모임 이름1",
-      date: "2024.06.01",
-      images: [.mock]
-    ),
-    .init(
-      id: 4,
-      name: "모임 이름1",
-      date: "2024.06.01",
-      images: [.mock]
-    ),
-    .init(
-      id: 5,
-      name: "모임 이름1",
-      date: "2024.06.01",
-      images: [.mock]
-    ),
-    .init(
-      id: 6,
-      name: "모임 이름1",
-      date: "2024.06.01",
-      images: [.mock]
+      images: [
+        .init(
+          imageURL: "https://picsum.photos/200",
+          frame: .snowman
+        ),
+        .init(
+          imageURL: "https://picsum.photos/201",
+          frame: .snowman
+        ),
+        .init(
+          imageURL: "https://picsum.photos/202",
+          frame: .snowman
+        ),
+        .init(
+          imageURL: "https://picsum.photos/203",
+          frame: .snowman
+        )
+      ]
     )
   ]
 }

--- a/Projects/Core/Models/Group/Response/GroupDetailInfo.swift
+++ b/Projects/Core/Models/Group/Response/GroupDetailInfo.swift
@@ -42,7 +42,7 @@ public struct GroupDetailInfo: Decodable {
       CardBackImage(imageURL: "https://24ai.tech/ru/wp-content/uploads/sites/4/2023/10/01_product_1_sdelat-kvadratnym-scaled.jpg", frame: .ghost),
       CardBackImage(imageURL: "https://24ai.tech/ru/wp-content/uploads/sites/4/2023/10/01_product_1_sdelat-kvadratnym-scaled.jpg", frame: .sexy)
     ],
-    history: History.listMomck
+    history: History.listMock
   )
   
   public init(
@@ -84,10 +84,27 @@ public struct History: Decodable, Identifiable, Equatable {
     id: 0,
     name: "모임 이름1",
     date: "2024.06.01",
-    images: [.mock]
+    images: [
+      .init(
+        imageURL: "https://picsum.photos/200",
+        frame: .snowman
+      ),
+      .init(
+        imageURL: "https://picsum.photos/201",
+        frame: .snowman
+      ),
+      .init(
+        imageURL: "https://picsum.photos/202",
+        frame: .snowman
+      ),
+      .init(
+        imageURL: "https://picsum.photos/203",
+        frame: .snowman
+      )
+    ]
   )
   
-  public static let listMomck: [History] = [
+  public static let listMock: [History] = [
     .init(
       id: 0,
       name: "모임 이름1",

--- a/Projects/Core/Models/Vote/Response/VoteCompleteInfo.swift
+++ b/Projects/Core/Models/Vote/Response/VoteCompleteInfo.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 
-// TODO: 실제 API 수정 후 반영 필요
 public struct VoteCompleteInfo: Decodable, Equatable {
   public var eventID: Int
   public var keyword: GroupData.Keyword
@@ -17,7 +16,7 @@ public struct VoteCompleteInfo: Decodable, Equatable {
   enum CodingKeys: String, CodingKey {
     case eventID = "event_id"
     case keyword
-    case imageURL = "image_url"
+    case imageURL = "random_image_url"
   }
   
   public static let mock: VoteCompleteInfo = .init(

--- a/Projects/Features/Coordinator/GroupDetailCoordinator/GroupDetailCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/GroupDetailCoordinator/GroupDetailCoordinatorCore.swift
@@ -1,0 +1,38 @@
+//
+//  GroupDetailCoordinatorCore.swift
+//  GroupDetailCoordinator
+//
+//  Created by hyerin on 8/12/24.
+//  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
+//
+
+import ComposableArchitecture
+import TCACoordinators
+
+@Reducer
+public struct GroupDetailCoordinatorCore {
+  public init() {}
+  
+  @ObservableState
+  public struct State: Equatable {
+    var routes: [Route<GroupDetailScreen.State>]
+    
+    public init(routes: [Route<GroupDetailScreen.State>]) {
+      self.routes = routes
+    }
+  }
+  
+  public enum Action {
+    case router(IndexedRouterActionOf<GroupDetailScreen>)
+  }
+  
+  public var body: some Reducer<State, Action> {
+    Reduce { state, action in
+      switch action {
+
+      }
+    }
+    .forEachRoute(\.routes, action: \.router)
+  }
+}
+

--- a/Projects/Features/Coordinator/GroupDetailCoordinator/GroupDetailCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/GroupDetailCoordinator/GroupDetailCoordinatorCore.swift
@@ -28,6 +28,35 @@ public struct GroupDetailCoordinatorCore {
   
   public var body: some Reducer<State, Action> {
     Reduce { state, action in
+      switch action {
+      case let .router(.routeAction(id: _, action: .groupDetail(.moveToHistoryDetail(history, keyword, domain)))):
+        state.routes.push(.historyDetail(.init(history: history, keyword: keyword, s3BucketDomain: domain)))
+        
+      case let .router(.routeAction(id: _, action: .groupDetail(.moveToMemberList(groupID)))):
+        state.routes.push(.memberList(.init(groupID: groupID)))
+        
+      case let .router(.routeAction(id: _, action: .groupDetail(.moveToVote(eventID)))):
+        state.routes.presentCover(.vote(.init(eventID: eventID)), embedInNavigationView: true)
+        
+      case .router(.routeAction(id: _, action: .historyDetail(.backToGroupDetail))):
+        state.routes.pop()
+        
+      case .router(.routeAction(id: _, action: .memberList(.backToGroupDetail))):
+        state.routes.pop()
+        
+      case .router(.routeAction(id: _, action: .vote(.dismissVoteView))):
+        state.routes.dismiss()
+        
+      case let .router(.routeAction(id: _, action: .vote(.moveToVoteComplete(voteCompleteInfo)))):
+        state.routes.push(.voteComplete(.init(voteResult: voteCompleteInfo)))
+        
+      case .router(.routeAction(id: _, action: .voteComplete(.backToGroupDetail))):
+        state.routes.dismiss()
+        
+      default:
+        break
+      }
+      
       return .none
     }
     .forEachRoute(\.routes, action: \.router)

--- a/Projects/Features/Coordinator/GroupDetailCoordinator/GroupDetailCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/GroupDetailCoordinator/GroupDetailCoordinatorCore.swift
@@ -28,9 +28,7 @@ public struct GroupDetailCoordinatorCore {
   
   public var body: some Reducer<State, Action> {
     Reduce { state, action in
-      switch action {
-
-      }
+      return .none
     }
     .forEachRoute(\.routes, action: \.router)
   }

--- a/Projects/Features/Coordinator/GroupDetailCoordinator/GroupDetailCoordinatorView.swift
+++ b/Projects/Features/Coordinator/GroupDetailCoordinator/GroupDetailCoordinatorView.swift
@@ -24,6 +24,14 @@ public struct GroupDetailCoordinatorView: View {
         switch screen.case {
         case let .groupDetail(store):
           GroupDetailView(store: store)
+        case let .historyDetail(store):
+          HistoryDetailView(store: store)
+        case let .memberList(store):
+          MemberListView(store: store)
+        case let .vote(store):
+          VoteView(store: store)
+        case let .voteComplete(store):
+          VoteCompleteView(store: store)
         }
       }
       .toolbar(.hidden)

--- a/Projects/Features/Coordinator/GroupDetailCoordinator/GroupDetailCoordinatorView.swift
+++ b/Projects/Features/Coordinator/GroupDetailCoordinator/GroupDetailCoordinatorView.swift
@@ -7,7 +7,7 @@
 //
 
 import ComposableArchitecture
-import CreateGroup
+import GroupDetail
 import SwiftUI
 import TCACoordinators
 
@@ -22,7 +22,8 @@ public struct GroupDetailCoordinatorView: View {
     TCARouter(store.scope(state: \.routes, action: \.router)) { screen in
       Group {
         switch screen.case {
-
+        case let .groupDetail(store):
+          GroupDetailView(store: store)
         }
       }
       .toolbar(.hidden)

--- a/Projects/Features/Coordinator/GroupDetailCoordinator/GroupDetailCoordinatorView.swift
+++ b/Projects/Features/Coordinator/GroupDetailCoordinator/GroupDetailCoordinatorView.swift
@@ -1,0 +1,32 @@
+//
+//  GroupDetailCoordinatorView.swift
+//  GroupDetailCoordinator
+//
+//  Created by hyerin on 8/12/24.
+//  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
+//
+
+import ComposableArchitecture
+import CreateGroup
+import SwiftUI
+import TCACoordinators
+
+public struct GroupDetailCoordinatorView: View {
+  let store: StoreOf<GroupDetailCoordinatorCore>
+  
+  public init(store: StoreOf<GroupDetailCoordinatorCore>) {
+    self.store = store
+  }
+  
+  public var body: some View {
+    TCARouter(store.scope(state: \.routes, action: \.router)) { screen in
+      Group {
+        switch screen.case {
+
+        }
+      }
+      .toolbar(.hidden)
+    }
+  }
+}
+

--- a/Projects/Features/Coordinator/GroupDetailCoordinator/GroupDetailScreen.swift
+++ b/Projects/Features/Coordinator/GroupDetailCoordinator/GroupDetailScreen.swift
@@ -12,6 +12,6 @@ import TCACoordinators
 
 @Reducer(state: .equatable)
 public enum GroupDetailScreen {
-  
+  case groupDetail(GroupDetailCore)
 }
 

--- a/Projects/Features/Coordinator/GroupDetailCoordinator/GroupDetailScreen.swift
+++ b/Projects/Features/Coordinator/GroupDetailCoordinator/GroupDetailScreen.swift
@@ -13,5 +13,9 @@ import TCACoordinators
 @Reducer(state: .equatable)
 public enum GroupDetailScreen {
   case groupDetail(GroupDetailCore)
+  case historyDetail(HistoryDetailCore)
+  case memberList(MemberListCore)
+  case vote(VoteCore)
+  case voteComplete(VoteCompleteCore)
 }
 

--- a/Projects/Features/Coordinator/GroupDetailCoordinator/GroupDetailScreen.swift
+++ b/Projects/Features/Coordinator/GroupDetailCoordinator/GroupDetailScreen.swift
@@ -1,0 +1,17 @@
+//
+//  GroupDetailScreen.swift
+//  GroupDetailCoordinator
+//
+//  Created by hyerin on 8/12/24.
+//  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
+//
+
+import ComposableArchitecture
+import GroupDetail
+import TCACoordinators
+
+@Reducer(state: .equatable)
+public enum GroupDetailScreen {
+  
+}
+

--- a/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorCore.swift
@@ -47,6 +47,9 @@ public struct MainCoordinatorCore {
       case .router(.routeAction(id: _, action: .createGroupCoordinator(.router(.routeAction(id: _, action: .createGroupCompletion(.backToHome)))))):
         state.routes.dismiss()
         
+      case let .router(.routeAction(id: _, action: .groupList(.moveToGroupDetail(groupID)))):
+        state.routes.push(.groupDetailCoordinator(.init(routes: [.root(.groupDetail(.init(groupID: groupID)), embedInNavigationView: true)])))
+        
       default:
         break
       }

--- a/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorCore.swift
@@ -48,10 +48,10 @@ public struct MainCoordinatorCore {
         state.routes.dismiss()
         
       case let .router(.routeAction(id: _, action: .groupList(.moveToGroupDetail(groupID)))):
-        state.routes.presentCover(.groupDetailCoordinator(.init(routes: [.root(.groupDetail(.init(groupID: groupID)), embedInNavigationView: true)])))
+        state.routes.push(.groupDetailCoordinator(.init(routes: [.root(.groupDetail(.init(groupID: groupID)))])))
         
       case .router(.routeAction(id: _, action: .groupDetailCoordinator(.router(.routeAction(id: _, action: .groupDetail(.backToHome)))))):
-        state.routes.dismiss()
+        state.routes.pop()
         
       default:
         break

--- a/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorCore.swift
@@ -48,7 +48,10 @@ public struct MainCoordinatorCore {
         state.routes.dismiss()
         
       case let .router(.routeAction(id: _, action: .groupList(.moveToGroupDetail(groupID)))):
-        state.routes.push(.groupDetailCoordinator(.init(routes: [.root(.groupDetail(.init(groupID: groupID)), embedInNavigationView: true)])))
+        state.routes.presentCover(.groupDetailCoordinator(.init(routes: [.root(.groupDetail(.init(groupID: groupID)), embedInNavigationView: true)])))
+        
+      case .router(.routeAction(id: _, action: .groupDetailCoordinator(.router(.routeAction(id: _, action: .groupDetail(.backToHome)))))):
+        state.routes.dismiss()
         
       default:
         break

--- a/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorView.swift
+++ b/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorView.swift
@@ -8,6 +8,7 @@
 
 import ComposableArchitecture
 import CreateGroupCoordinator
+import GroupDetailCoordinator
 import Main
 import MyPage
 import SwiftUI
@@ -31,6 +32,8 @@ public struct MainCoordinatorView: View {
         GroupListView(store: store)
       case let .joinGroup(store):
         JoinGroupView(store: store)
+      case let .groupDetailCoordinator(store):
+        GroupDetailCoordinatorView(store: store)
       }
     }
   }

--- a/Projects/Features/Coordinator/MainCoordinator/MainScreen.swift
+++ b/Projects/Features/Coordinator/MainCoordinator/MainScreen.swift
@@ -8,6 +8,7 @@
 
 import ComposableArchitecture
 import CreateGroupCoordinator
+import GroupDetailCoordinator
 import Main
 import MyPage
 import TCACoordinators
@@ -18,4 +19,5 @@ public enum MainScreen {
   case myPage(MyPageCore)
   case groupList(GroupListCore)
   case joinGroup(JoinGroupCore)
+  case groupDetailCoordinator(GroupDetailCoordinatorCore)
 }

--- a/Projects/Features/Coordinator/Project.swift
+++ b/Projects/Features/Coordinator/Project.swift
@@ -24,6 +24,7 @@ let project = Project.make(
         .project(target: .myPage, projectPath: .scene),
         .project(target: .login, projectPath: .scene),
         .target(name: .createGroupCoordinator),
+        .target(name: .groupDetailCoordinator),
         .external(externalDependency: .composableArchitecture),
         .external(externalDependency: .tcaCoordinators),
       ]
@@ -37,6 +38,17 @@ let project = Project.make(
         .project(target: .createGroup, projectPath: .scene),
         .external(externalDependency: .composableArchitecture),
         .external(externalDependency: .tcaCoordinators),
+      ]
+    ),
+    .make(
+      name: "GroupDetailCoordinator",
+      product: .staticLibrary,
+      bundleId: "com.mashup.gabbangzip.groupDetailCoordinator",
+      sources: ["GroupDetailCoordinator/**"],
+      dependencies: [
+        .project(target: .groupDetail, projectPath: .scene),
+        .external(externalDependency: .composableArchitecture),
+        .external(externalDependency: .tcaCoordinators)
       ]
     )
   ]

--- a/Projects/Features/Scene/CreateGroupScene/CreateGroupCompletion/CreateGroupCompletionView.swift
+++ b/Projects/Features/Scene/CreateGroupScene/CreateGroupCompletion/CreateGroupCompletionView.swift
@@ -58,7 +58,11 @@ public struct CreateGroupCompletionView: View {
         .foregroundStyle(DesignSystem.Colors.gray60)
         .padding(.top, 16)
       
-      SmallButton(type: .active, smallButtonContentType: .copyCode, action: { store.send(.copyLinkButtonTapped) })
+      SmallButton(
+        type: .active,
+        smallButtonContentType: .copyCode,
+        action: { store.send(.copyLinkButtonTapped) }
+      )
         .padding(.top, 8)
       
       Spacer()

--- a/Projects/Features/Scene/GroupDetailScene/GroupDetail/EventContainer/EventCompletedView/EventCompletedView.swift
+++ b/Projects/Features/Scene/GroupDetailScene/GroupDetail/EventContainer/EventCompletedView/EventCompletedView.swift
@@ -33,11 +33,9 @@ public struct EventCompletedView: View {
       .padding(.vertical, 16)
       
       ShareButton(action: {
-        // TODO
-//        store.send(.shareButtonTapped)
         captureView(of: completedImage) { capturedImage in
-          // TODO
-//          store.send(.imageCaptured(capturedImage))
+          store.send(.imageCaptured(capturedImage))
+          store.send(.shareButtonTapped)
         }
       })
         .padding(.bottom, 32)

--- a/Projects/Features/Scene/GroupDetailScene/GroupDetail/EventContainer/EventCompletedView/EventCompletedView.swift
+++ b/Projects/Features/Scene/GroupDetailScene/GroupDetail/EventContainer/EventCompletedView/EventCompletedView.swift
@@ -48,15 +48,20 @@ public struct EventCompletedView: View {
     )
   }
   
+  @ViewBuilder
   private var completedImage: some View {
-    PhotoCard(status: store.groupDetail.keyword.convertToPhotoCardStatus()) {
-      PhotoCardBackView(
-        recentEventDate: store.groupDetail.recentEventDetail.date,
-        cardBackImages: store.groupDetail.cardBackImages,
-        recentEventName: store.groupDetail.recentEventDetail.name,
-        foregroundColor: store.groupDetail.keyword.foregroundColor,
-        s3BucketDomain: store.s3BucketDomain
-      )
+    if let groupDetail = store.groupDetail {
+      PhotoCard(status: groupDetail.keyword.convertToPhotoCardStatus()) {
+        PhotoCardBackView(
+          recentEventDate: groupDetail.recentEventDetail.date,
+          cardBackImages: groupDetail.cardBackImages,
+          recentEventName: groupDetail.recentEventDetail.name,
+          foregroundColor: groupDetail.keyword.foregroundColor,
+          s3BucketDomain: store.s3BucketDomain
+        )
+      }
+    } else {
+      EmptyView()
     }
   }
 }

--- a/Projects/Features/Scene/GroupDetailScene/GroupDetail/EventContainer/EventContainerView.swift
+++ b/Projects/Features/Scene/GroupDetailScene/GroupDetail/EventContainer/EventContainerView.swift
@@ -13,12 +13,12 @@ import NukeUI
 import SwiftUI
 
 struct EventContainerView: View {
-  private let groupDetail: GroupDetailInfo
+  private let groupDetail: GroupDetailInfo?
   private var action: (GroupData.Status) -> Void
   private var store: StoreOf<GroupDetailCore>
   
   init(
-    groupDetail: GroupDetailInfo,
+    groupDetail: GroupDetailInfo?,
     action: @escaping (GroupData.Status) -> Void,
     store: StoreOf<GroupDetailCore>
   ) {
@@ -28,19 +28,23 @@ struct EventContainerView: View {
   }
   
   var body: some View {
-    switch groupDetail.status {
-    case .beforeMyUpload, .afterMyUpload, .beforeMyVote, .afterMyVote:
-      EventProgressView(
-        groupDetail: groupDetail,
-        action: {
-          action(groupDetail.status)
-        },
-        store: store
-      )
-    case .noCurrentEvent, .eventCompleted:
-      EventCompletedView(store: store)
-    case .noPastAndCurrentEvent:
-      // 해당 화면에 접근 불가능한 조건
+    if let groupDetail {
+      switch groupDetail.status {
+      case .beforeMyUpload, .afterMyUpload, .beforeMyVote, .afterMyVote:
+        EventProgressView(
+          groupDetail: groupDetail,
+          action: {
+            action(groupDetail.status)
+          },
+          store: store
+        )
+      case .noCurrentEvent, .eventCompleted:
+        EventCompletedView(store: store)
+      case .noPastAndCurrentEvent:
+        // 해당 화면에 접근 불가능한 조건
+        EmptyView()
+      }
+    } else {
       EmptyView()
     }
   }

--- a/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailCore.swift
+++ b/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailCore.swift
@@ -97,8 +97,8 @@ public struct GroupDetailCore {
 
     // Route Action
     case backToHome
-    case moveToMemberList
-    case moveToVote
+    case moveToMemberList(Int)
+    case moveToVote(Int)
     case moveToHistoryDetail(History, GroupData.Keyword, String)
   }
 
@@ -124,12 +124,12 @@ public struct GroupDetailCore {
         return .send(.backToHome)
         
       case .memberListButtonTapped:
-        return .send(.moveToMemberList)
+        return .send(.moveToMemberList(state.groupID))
         
       case let .eventContainerViewButtonTapped(status):
         switch status {
         case .beforeMyVote:
-          return .send(.moveToVote)
+          return .send(.moveToVote(state.groupDetail.recentEventDetail.id))
         case .afterMyVote, .afterMyUpload:
           return .run { [state] send in
             await send(.postKook(Result {

--- a/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailCore.swift
+++ b/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailCore.swift
@@ -85,6 +85,7 @@ public struct GroupDetailCore {
     case memberListButtonTapped
     case eventContainerViewButtonTapped(GroupData.Status)
     case selectedPhotos([PhotoInfo])
+    case historyViewTapped(History)
 
     // Internal Action
     case getGroupDetailResponse(Result<GroupDetailInfo, Error>)
@@ -98,6 +99,7 @@ public struct GroupDetailCore {
     case backToHome
     case moveToMemberList
     case moveToVote
+    case moveToHistoryDetail(History, GroupData.Keyword, String)
   }
 
   public var body: some Reducer<State, Action> {
@@ -152,6 +154,9 @@ public struct GroupDetailCore {
             )
           }
         }
+        
+      case let .historyViewTapped(history):
+        return .send(GroupDetailCore.Action.moveToHistoryDetail(history, state.groupDetail.keyword, state.s3BucketDomain))
         
       // Internal Action
       case let .getGroupDetailResponse(.success(groupDetailInfo)):
@@ -216,6 +221,9 @@ public struct GroupDetailCore {
         return .none
         
       case .moveToVote:
+        return .none
+        
+      case .moveToHistoryDetail:
         return .none
       }
     }

--- a/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailCore.swift
+++ b/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailCore.swift
@@ -14,6 +14,8 @@ import UIKit
 
 @Reducer
 public struct GroupDetailCore {
+  public init() {}
+  
   @ObservableState
   public struct State: Equatable {
     var groupID: Int
@@ -46,14 +48,14 @@ public struct GroupDetailCore {
 
     public init(
       groupID: Int,
-      groupDetail: GroupDetailInfo,
+      groupDetail: GroupDetailInfo = .mock,
       showSheet: Bool = true,
-      selectedPhotosInfo: [PhotoInfo],
+      selectedPhotosInfo: [PhotoInfo] = [],
       isToastPresented: Bool = false,
-      toastType: ToastType,
-      s3BucketDomain: String,
-      showActivityView: Bool,
-      capturedImage: UIImage?,
+      toastType: ToastType = .onlyText(""),
+      s3BucketDomain: String = "",
+      showActivityView: Bool = false,
+      capturedImage: UIImage? = nil,
       userInfo: @autoclosure () -> UserInfo = .defaultValue
     ) {
       self.groupID = groupID

--- a/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailCore.swift
+++ b/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailCore.swift
@@ -86,6 +86,8 @@ public struct GroupDetailCore {
     case eventContainerViewButtonTapped(GroupData.Status)
     case selectedPhotos([PhotoInfo])
     case historyViewTapped(History)
+    case shareButtonTapped
+    case imageCaptured(UIImage?)
 
     // Internal Action
     case getGroupDetailResponse(Result<GroupDetailInfo, Error>)
@@ -157,6 +159,14 @@ public struct GroupDetailCore {
         
       case let .historyViewTapped(history):
         return .send(GroupDetailCore.Action.moveToHistoryDetail(history, state.groupDetail.keyword, state.s3BucketDomain))
+        
+      case .shareButtonTapped:
+        state.showActivityView = true
+        return .none
+        
+      case let .imageCaptured(image):
+        state.capturedImage = image
+        return .none
         
       // Internal Action
       case let .getGroupDetailResponse(.success(groupDetailInfo)):

--- a/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailCore.swift
+++ b/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailCore.swift
@@ -19,7 +19,7 @@ public struct GroupDetailCore {
   @ObservableState
   public struct State: Equatable {
     var groupID: Int
-    var groupDetail: GroupDetailInfo
+    var groupDetail: GroupDetailInfo?
     var showSheet: Bool
     var selectedPhotosInfo: [PhotoInfo]
     var isToastPresented: Bool
@@ -28,27 +28,31 @@ public struct GroupDetailCore {
     var showActivityView: Bool
     var capturedImage: UIImage?
     var smallButtonType: SmallButtonContentType {
-      switch groupDetail.status {
-      case .noCurrentEvent, .noPastAndCurrentEvent, .eventCompleted:
+      if let groupDetail {
+        switch groupDetail.status {
+        case .noCurrentEvent, .noPastAndCurrentEvent, .eventCompleted:
+          return .generateEvent
+        case .beforeMyUpload:
+          return .uploadPIC
+        case .beforeMyVote:
+          return .vote
+        case .afterMyUpload, .afterMyVote:
+          return .stabbing
+        }
+      } else {
         return .generateEvent
-      case .beforeMyUpload:
-        return .uploadPIC
-      case .beforeMyVote:
-        return .vote
-      case .afterMyUpload, .afterMyVote:
-        return .stabbing
       }
     }
     
     var isNeedEventCompletedTitle: Bool {
-      return groupDetail.status == .eventCompleted
+      return groupDetail?.status == .eventCompleted
     }
     
     @Shared var userInfo: UserInfo
 
     public init(
       groupID: Int,
-      groupDetail: GroupDetailInfo = .mock,
+      groupDetail: GroupDetailInfo? = nil,
       showSheet: Bool = true,
       selectedPhotosInfo: [PhotoInfo] = [],
       isToastPresented: Bool = false,
@@ -101,7 +105,7 @@ public struct GroupDetailCore {
     case backToHome
     case moveToMemberList(Int)
     case moveToVote(Int)
-    case moveToHistoryDetail(History, GroupData.Keyword, String)
+    case moveToHistoryDetail(History, GroupData.Keyword?, String)
   }
 
   public var body: some Reducer<State, Action> {
@@ -131,11 +135,14 @@ public struct GroupDetailCore {
       case let .eventContainerViewButtonTapped(status):
         switch status {
         case .beforeMyVote:
-          return .send(.moveToVote(state.groupDetail.recentEventDetail.id))
+          return .send(.moveToVote(state.groupDetail?.recentEventDetail.id ?? 0))
         case .afterMyVote, .afterMyUpload:
           return .run { [state] send in
             await send(.postKook(Result {
-              try await self.pushAPIClienet.kook(accessToken: state.userInfo.accessToken, eventID: state.groupDetail.recentEventDetail.id)
+              try await self.pushAPIClienet.kook(
+                accessToken: state.userInfo.accessToken,
+                eventID: state.groupDetail?.recentEventDetail.id ?? 0
+              )
             }))
           }
         default:
@@ -158,7 +165,7 @@ public struct GroupDetailCore {
         }
         
       case let .historyViewTapped(history):
-        return .send(GroupDetailCore.Action.moveToHistoryDetail(history, state.groupDetail.keyword, state.s3BucketDomain))
+        return .send(GroupDetailCore.Action.moveToHistoryDetail(history, state.groupDetail?.keyword, state.s3BucketDomain))
         
       case .shareButtonTapped:
         state.showActivityView = true
@@ -172,13 +179,13 @@ public struct GroupDetailCore {
       case let .getGroupDetailResponse(.success(groupDetailInfo)):
         state.groupDetail = groupDetailInfo
         
-        if state.groupDetail.status == .eventCompleted {
+        if state.groupDetail?.status == .eventCompleted {
           return .run(
             operation: { [state] send in
               await send(.putEventVisit(Result {
                 try await self.eventAPIClient.putEventVisit(
                   accessToken: state.userInfo.accessToken,
-                  eventID: state.groupDetail.recentEventDetail.id
+                  eventID: state.groupDetail?.recentEventDetail.id ?? -1
                 )
               }))
             }

--- a/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailView.swift
+++ b/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailView.swift
@@ -49,7 +49,11 @@ public struct GroupDetailView: View {
     .scrollIndicators(.hidden)
     .background(DesignSystem.Colors.gray20)
     .sheet(isPresented: $store.showSheet) {
-      HistoryGridView(histories: store.groupDetail.history)
+      HistoryGridView(
+        histories: store.groupDetail.history,
+        keyword: store.groupDetail.keyword,
+        s3BucketDomain: store.s3BucketDomain
+      )
         .presentationDetents([.height(bottomSheetHeight), .large])
         .interactiveDismissDisabled()
         .presentationDragIndicator(.hidden)

--- a/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailView.swift
+++ b/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailView.swift
@@ -52,7 +52,10 @@ public struct GroupDetailView: View {
       HistoryGridView(
         histories: store.groupDetail.history,
         keyword: store.groupDetail.keyword,
-        s3BucketDomain: store.s3BucketDomain
+        s3BucketDomain: store.s3BucketDomain,
+        tapAction: { history in
+          store.send(.historyViewTapped(history))
+        }
       )
         .presentationDetents([.height(bottomSheetHeight), .large])
         .interactiveDismissDisabled()

--- a/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailView.swift
+++ b/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailView.swift
@@ -24,7 +24,7 @@ public struct GroupDetailView: View {
     ScrollView {
       VStack(spacing: 0) {
         NavigationBar(
-          type: .titleWithBackButtonAndIcon(store.groupDetail.name, DesignSystem.Icons.group),
+          type: .titleWithBackButtonAndIcon(store.groupDetail?.name ?? "", DesignSystem.Icons.group),
           backButtonAction: {
             store.send(.backButtonTapped)
           },
@@ -50,8 +50,8 @@ public struct GroupDetailView: View {
     .background(DesignSystem.Colors.gray20)
     .sheet(isPresented: $store.showSheet) {
       HistoryGridView(
-        histories: store.groupDetail.history,
-        keyword: store.groupDetail.keyword,
+        histories: store.groupDetail?.history,
+        keyword: store.groupDetail?.keyword,
         s3BucketDomain: store.s3BucketDomain,
         tapAction: { history in
           store.send(.historyViewTapped(history))

--- a/Projects/Features/Scene/GroupDetailScene/GroupDetail/HistoryGrid/HistoryGridView.swift
+++ b/Projects/Features/Scene/GroupDetailScene/GroupDetail/HistoryGrid/HistoryGridView.swift
@@ -12,10 +12,18 @@ import SwiftUI
 
 struct HistoryGridView: View {
   private let histories: [History]
-  private let columns = [GridItem(spacing: 33), GridItem(spacing: 33)]
+  private let keyword: GroupData.Keyword
+  private let s3BucketDomain: String
+  private let columns = [GridItem(spacing: 9), GridItem(spacing: 9)]
   
-  init(histories: [History]) {
+  init(
+    histories: [History],
+    keyword: GroupData.Keyword,
+    s3BucketDomain: String
+  ) {
     self.histories = histories
+    self.keyword = keyword
+    self.s3BucketDomain = s3BucketDomain
   }
   
   var body: some View {
@@ -46,7 +54,11 @@ struct HistoryGridView: View {
   private var galleryView: some View {
     LazyVGrid(columns: columns, spacing: 16) {
       ForEach(histories) { history in
-        HistoryItemView(history: history)
+        HistoryItemView(
+          history: history,
+          keyword: keyword,
+          s3BucketDomain: s3BucketDomain
+        )
       }
     }
     .padding(.top, 17)
@@ -67,11 +79,9 @@ struct HistoryGridView: View {
 }
 
 #Preview {
-  Group {
-    HistoryGridView(histories: [])
-  }
-}
-
-#Preview {
-  HistoryGridView(histories: History.listMomck)
+  HistoryGridView(
+    histories: History.listMock,
+    keyword: .company,
+    s3BucketDomain: ""
+  )
 }

--- a/Projects/Features/Scene/GroupDetailScene/GroupDetail/HistoryGrid/HistoryGridView.swift
+++ b/Projects/Features/Scene/GroupDetailScene/GroupDetail/HistoryGrid/HistoryGridView.swift
@@ -15,15 +15,18 @@ struct HistoryGridView: View {
   private let keyword: GroupData.Keyword
   private let s3BucketDomain: String
   private let columns = [GridItem(spacing: 9), GridItem(spacing: 9)]
+  private let tapAction: (History) -> Void
   
   init(
     histories: [History],
     keyword: GroupData.Keyword,
-    s3BucketDomain: String
+    s3BucketDomain: String,
+    tapAction: @escaping (History) -> Void
   ) {
     self.histories = histories
     self.keyword = keyword
     self.s3BucketDomain = s3BucketDomain
+    self.tapAction = tapAction
   }
   
   var body: some View {
@@ -57,7 +60,10 @@ struct HistoryGridView: View {
         HistoryItemView(
           history: history,
           keyword: keyword,
-          s3BucketDomain: s3BucketDomain
+          s3BucketDomain: s3BucketDomain,
+          tapAction: { history in
+            tapAction(history)
+          }
         )
       }
     }
@@ -83,5 +89,5 @@ struct HistoryGridView: View {
     histories: History.listMock,
     keyword: .company,
     s3BucketDomain: ""
-  )
+  ) { _ in }
 }

--- a/Projects/Features/Scene/GroupDetailScene/GroupDetail/HistoryGrid/HistoryGridView.swift
+++ b/Projects/Features/Scene/GroupDetailScene/GroupDetail/HistoryGrid/HistoryGridView.swift
@@ -11,15 +11,15 @@ import Models
 import SwiftUI
 
 struct HistoryGridView: View {
-  private let histories: [History]
-  private let keyword: GroupData.Keyword
+  private let histories: [History]?
+  private let keyword: GroupData.Keyword?
   private let s3BucketDomain: String
   private let columns = [GridItem(spacing: 9), GridItem(spacing: 9)]
   private let tapAction: (History) -> Void
   
   init(
-    histories: [History],
-    keyword: GroupData.Keyword,
+    histories: [History]?,
+    keyword: GroupData.Keyword?,
     s3BucketDomain: String,
     tapAction: @escaping (History) -> Void
   ) {
@@ -33,10 +33,10 @@ struct HistoryGridView: View {
     ScrollView {
       titleView
       
-      if histories.isEmpty {
-        emptyView
-      } else {
+      if let histories, !histories.isEmpty {
         galleryView
+      } else {
+        emptyView
       }
     }
     .padding(.horizontal, 16)
@@ -56,15 +56,17 @@ struct HistoryGridView: View {
   
   private var galleryView: some View {
     LazyVGrid(columns: columns, spacing: 16) {
-      ForEach(histories) { history in
-        HistoryItemView(
-          history: history,
-          keyword: keyword,
-          s3BucketDomain: s3BucketDomain,
-          tapAction: { history in
-            tapAction(history)
-          }
-        )
+      if let histories, let keyword {
+        ForEach(histories) { history in
+          HistoryItemView(
+            history: history,
+            keyword: keyword,
+            s3BucketDomain: s3BucketDomain,
+            tapAction: { history in
+              tapAction(history)
+            }
+          )
+        }
       }
     }
     .padding(.top, 17)

--- a/Projects/Features/Scene/GroupDetailScene/GroupDetail/HistoryGrid/HistoryItemView.swift
+++ b/Projects/Features/Scene/GroupDetailScene/GroupDetail/HistoryGrid/HistoryItemView.swift
@@ -7,36 +7,31 @@
 //
 
 import DesignSystem
+import Lovebug
 import Models
 import NukeUI
 import SwiftUI
 
 struct HistoryItemView: View {
   private let history: History
+  private let columns = [GridItem(spacing: 12), GridItem(spacing: 12)]
+  private let keyword: GroupData.Keyword
+  private let s3BucketDomain: String
   
-  init(history: History) {
+  init(
+    history: History,
+    keyword: GroupData.Keyword,
+    s3BucketDomain: String
+  ) {
     self.history = history
+    self.keyword = keyword
+    self.s3BucketDomain = s3BucketDomain
   }
   
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
-      if let firstImageURL = history.images.first?.imageURL,
-         let url = URL(string: firstImageURL) {
-        LazyImage(url: url) { state in
-          if let image = state.image {
-            image.resizable()
-              .aspectRatio(contentMode: .fit)
-          } else {
-            // 로딩 중 혹은 실패 시
-            placeHolder
-          }
-        }
-        .padding(.bottom, 8)
-      } else {
-        // imageURL 미존재 시
-        placeHolder
-          .padding(.bottom, 8)
-      }
+      photoView
+        .padding(.bottom, 6)
       
       Text(history.name)
         .font(.head18)
@@ -49,15 +44,29 @@ struct HistoryItemView: View {
     }
   }
   
-  // TODO: 디자인팀과 논의 필요
-  private var placeHolder: some View {
-    DesignSystem.Images.empty
+  var photoView: some View {
+    LazyVGrid(columns: columns, spacing: 12) {
+      ForEach(history.images, id: \.self) { card in
+        PhotoWithFrame(
+          frameShape: card.frame.image,
+          foregroundColor: keyword.backgroundColor,
+          imageURLString: s3BucketDomain + card.imageURL
+        )
+      }
+    }
+    .padding(12)
+    .background(keyword.backgroundColor)
+    .cornerRadius(20)
   }
 }
 
 #Preview {
   HStack(spacing: 33) {
-    HistoryItemView(history: .mock)
+    HistoryItemView(
+      history: .mock,
+      keyword: .company,
+      s3BucketDomain: ""
+    )
   }
   .padding(.horizontal, 20)
 }

--- a/Projects/Features/Scene/GroupDetailScene/GroupDetail/HistoryGrid/HistoryItemView.swift
+++ b/Projects/Features/Scene/GroupDetailScene/GroupDetail/HistoryGrid/HistoryItemView.swift
@@ -17,15 +17,18 @@ struct HistoryItemView: View {
   private let columns = [GridItem(spacing: 12), GridItem(spacing: 12)]
   private let keyword: GroupData.Keyword
   private let s3BucketDomain: String
+  private let tapAction: (History) -> Void
   
   init(
     history: History,
     keyword: GroupData.Keyword,
-    s3BucketDomain: String
+    s3BucketDomain: String,
+    tapAction: @escaping (History) -> Void
   ) {
     self.history = history
     self.keyword = keyword
     self.s3BucketDomain = s3BucketDomain
+    self.tapAction = tapAction
   }
   
   var body: some View {
@@ -42,6 +45,7 @@ struct HistoryItemView: View {
         .font(.caption12)
         .foregroundStyle(DesignSystem.Colors.gray60)
     }
+    .onTapGesture { tapAction(history) }
   }
   
   var photoView: some View {
@@ -66,7 +70,7 @@ struct HistoryItemView: View {
       history: .mock,
       keyword: .company,
       s3BucketDomain: ""
-    )
+    ) { _ in }
   }
   .padding(.horizontal, 20)
 }

--- a/Projects/Features/Scene/GroupDetailScene/HistoryDetail/HistoryDetailCore.swift
+++ b/Projects/Features/Scene/GroupDetailScene/HistoryDetail/HistoryDetailCore.swift
@@ -16,12 +16,12 @@ public struct HistoryDetailCore {
   @ObservableState
   public struct State: Equatable {
     var history: History
-    var keyword: GroupData.Keyword
+    var keyword: GroupData.Keyword?
     var s3BucketDomain: String
     
     public init(
       history: History,
-      keyword: GroupData.Keyword,
+      keyword: GroupData.Keyword?,
       s3BucketDomain: String
     ) {
       self.history = history

--- a/Projects/Features/Scene/GroupDetailScene/HistoryDetail/HistoryDetailCore.swift
+++ b/Projects/Features/Scene/GroupDetailScene/HistoryDetail/HistoryDetailCore.swift
@@ -11,6 +11,8 @@ import Models
 
 @Reducer
 public struct HistoryDetailCore {
+  public init() {}
+  
   @ObservableState
   public struct State: Equatable {
     var history: History

--- a/Projects/Features/Scene/GroupDetailScene/HistoryDetail/HistoryDetailCore.swift
+++ b/Projects/Features/Scene/GroupDetailScene/HistoryDetail/HistoryDetailCore.swift
@@ -42,7 +42,7 @@ public struct HistoryDetailCore {
     Reduce { state, action in
       switch action {
       case .backButtonTapped:
-        return .none
+        return .send(.backToGroupDetail)
         
       case .backToGroupDetail:
         return .none

--- a/Projects/Features/Scene/GroupDetailScene/HistoryDetail/HistoryDetailCore.swift
+++ b/Projects/Features/Scene/GroupDetailScene/HistoryDetail/HistoryDetailCore.swift
@@ -14,20 +14,35 @@ public struct HistoryDetailCore {
   @ObservableState
   public struct State: Equatable {
     var history: History
+    var keyword: GroupData.Keyword
+    var s3BucketDomain: String
     
-    public init(history: History) {
+    public init(
+      history: History,
+      keyword: GroupData.Keyword,
+      s3BucketDomain: String
+    ) {
       self.history = history
+      self.keyword = keyword
+      self.s3BucketDomain = s3BucketDomain
     }
   }
 
   public enum Action {
+    // View Action
     case backButtonTapped
+    
+    // Route Action
+    case backToGroupDetail
   }
 
   public var body: some Reducer<State, Action> {
     Reduce { state, action in
       switch action {
       case .backButtonTapped:
+        return .none
+        
+      case .backToGroupDetail:
         return .none
       }
     }

--- a/Projects/Features/Scene/GroupDetailScene/HistoryDetail/HistoryDetailView.swift
+++ b/Projects/Features/Scene/GroupDetailScene/HistoryDetail/HistoryDetailView.swift
@@ -16,7 +16,7 @@ public struct HistoryDetailView: View {
   private let store: StoreOf<HistoryDetailCore>
   private let background = DesignSystem.Colors.gray100
 
-  init(store: StoreOf<HistoryDetailCore>) {
+  public init(store: StoreOf<HistoryDetailCore>) {
     self.store = store
   }
 

--- a/Projects/Features/Scene/GroupDetailScene/HistoryDetail/HistoryDetailView.swift
+++ b/Projects/Features/Scene/GroupDetailScene/HistoryDetail/HistoryDetailView.swift
@@ -35,18 +35,21 @@ public struct HistoryDetailView: View {
         )
         .padding(.bottom, 50)
         
-        PhotoCard(
-          status: store.keyword.convertToPhotoCardStatus()) {
+        if let keyword = store.keyword {
+          PhotoCard(
+            status: keyword.convertToPhotoCardStatus()
+          ) {
             PhotoCardBackView(
               recentEventDate: store.history.date,
               cardBackImages: store.history.images,
               recentEventName: store.history.name,
-              foregroundColor: store.keyword.foregroundColor,
+              foregroundColor: keyword.foregroundColor,
               s3BucketDomain: store.s3BucketDomain
             )
           }
-        
-        Spacer()
+
+          Spacer()
+        }
       }
     }
   }

--- a/Projects/Features/Scene/GroupDetailScene/HistoryDetail/HistoryDetailView.swift
+++ b/Projects/Features/Scene/GroupDetailScene/HistoryDetail/HistoryDetailView.swift
@@ -8,6 +8,7 @@
 
 import ComposableArchitecture
 import DesignSystem
+import Lovebug
 import Models
 import SwiftUI
 
@@ -34,9 +35,16 @@ public struct HistoryDetailView: View {
         )
         .padding(.bottom, 50)
         
-        // TODO: 이미지 생성 필요
-        RoundedRectangle(cornerRadius: 5)
-          .foregroundStyle(.red)
+        PhotoCard(
+          status: store.keyword.convertToPhotoCardStatus()) {
+            PhotoCardBackView(
+              recentEventDate: store.history.date,
+              cardBackImages: store.history.images,
+              recentEventName: store.history.name,
+              foregroundColor: store.keyword.foregroundColor,
+              s3BucketDomain: store.s3BucketDomain
+            )
+          }
         
         Spacer()
       }
@@ -46,10 +54,15 @@ public struct HistoryDetailView: View {
 
 #Preview {
   HistoryDetailView(
-    store: Store(initialState: .init(
-      history: .mock)
-    ) {
-      HistoryDetailCore()
-    }
+    store: .init(
+      initialState: .init(
+        history: .mock,
+        keyword: .company,
+        s3BucketDomain: ""
+      ),
+      reducer: {
+        HistoryDetailCore()
+      }
+    )
   )
 }

--- a/Projects/Features/Scene/GroupDetailScene/MemberList/MemberListCore.swift
+++ b/Projects/Features/Scene/GroupDetailScene/MemberList/MemberListCore.swift
@@ -17,10 +17,10 @@ public struct MemberListCore {
   @ObservableState
   public struct State: Equatable {
     var groupID: Int
-    var memberList: MemberList
+    var memberList: MemberList?
     var groupKeyword: GroupData.Keyword
     var isFullCapacity: Bool {
-      memberList.members.count == 4
+      memberList?.members.count == 4
     }
     var inviteMemberMessage: String {
       isFullCapacity ? "그룹 최대 인원은 4명이에요." : "그룹원을 추가하고 싶으세요?"
@@ -29,7 +29,7 @@ public struct MemberListCore {
     
     public init(
       groupID: Int,
-      memberList: MemberList = .mock,
+      memberList: MemberList? = nil,
       groupKeyword: GroupData.Keyword = .company,
       userInfo: @autoclosure () -> UserInfo = .defaultValue
     ) {
@@ -71,7 +71,7 @@ public struct MemberListCore {
         
       case .copyLinkButtonTapped:
         return .run { [state] send in
-          uiPasteBoardClient.copyTextToClipboard(state.memberList.invitationCode)
+          uiPasteBoardClient.copyTextToClipboard(state.memberList?.invitationCode ?? "")
         }
         
       case .backButtonTapped:

--- a/Projects/Features/Scene/GroupDetailScene/MemberList/MemberListCore.swift
+++ b/Projects/Features/Scene/GroupDetailScene/MemberList/MemberListCore.swift
@@ -12,6 +12,8 @@ import Services
 
 @Reducer
 public struct MemberListCore {
+  public init() {}
+  
   @ObservableState
   public struct State: Equatable {
     var groupID: Int
@@ -27,8 +29,8 @@ public struct MemberListCore {
     
     public init(
       groupID: Int,
-      memberList: MemberList,
-      groupKeyword: GroupData.Keyword,
+      memberList: MemberList = .mock,
+      groupKeyword: GroupData.Keyword = .company,
       userInfo: @autoclosure () -> UserInfo = .defaultValue
     ) {
       self.groupID = groupID

--- a/Projects/Features/Scene/GroupDetailScene/MemberList/MemberListView.swift
+++ b/Projects/Features/Scene/GroupDetailScene/MemberList/MemberListView.swift
@@ -28,7 +28,7 @@ public struct MemberListView: View {
       )
       .padding(.bottom, 8)
       
-      ForEach(store.memberList.members, id: \.id) { member in
+      ForEach(store.memberList?.members ?? [], id: \.id) { member in
         MemberView(
           member: member,
           groupKeyword: store.groupKeyword

--- a/Projects/Features/Scene/GroupDetailScene/MemberList/MemberListView.swift
+++ b/Projects/Features/Scene/GroupDetailScene/MemberList/MemberListView.swift
@@ -11,14 +11,14 @@ import DesignSystem
 import Models
 import SwiftUI
 
-struct MemberListView: View {
+public struct MemberListView: View {
   private let store: StoreOf<MemberListCore>
 
-  init(store: StoreOf<MemberListCore>) {
+  public init(store: StoreOf<MemberListCore>) {
     self.store = store
   }
 
-  var body: some View {
+  public var body: some View {
     VStack(spacing: 0) {
       NavigationBar(
         type: .titleWithBackButton("그룹원", .center),

--- a/Projects/Features/Scene/GroupDetailScene/Vote/Vote/VoteCore.swift
+++ b/Projects/Features/Scene/GroupDetailScene/Vote/Vote/VoteCore.swift
@@ -39,20 +39,20 @@ public struct VoteCore {
     
     public init(
       userInfo: @autoclosure () -> UserInfo = .defaultValue,
-      voteButtonState: VoteButtonState,
-      passsButtonState: VoteButtonState,
+      voteButtonState: VoteButtonState = .defaultState,
+      passsButtonState: VoteButtonState = .defaultState,
       eventID: Int,
-      voteOptions: [VoteOptionInfo],
-      pickedImageIDs: [Int],
-      swipeDirection: SwipeDirection,
-      isPopupPresented: Bool,
-      isToastPresented: Bool,
-      popupType: VotePopupType,
-      toastType: VoteToastType,
-      isFirstVoteDone: Bool,
-      isNeedGuideView: Bool,
-      isVoteButtonDisabled: Bool,
-      guideTypes: [GuideType]
+      voteOptions: [VoteOptionInfo] = [],
+      pickedImageIDs: [Int] = [],
+      swipeDirection: SwipeDirection = .defaultState,
+      isPopupPresented: Bool = false,
+      isToastPresented: Bool = false,
+      popupType: VotePopupType = .close,
+      toastType: VoteToastType = .error,
+      isFirstVoteDone: Bool = false,
+      isNeedGuideView: Bool = false,
+      isVoteButtonDisabled: Bool = false,
+      guideTypes: [GuideType] = [.pass, .vote]
     ) {
       self._userInfo = Shared(wrappedValue: userInfo(), .inMemory("userInfo"))
       self.voteButtonState = voteButtonState
@@ -100,6 +100,7 @@ public struct VoteCore {
     
     // Route Action
     case dismissVoteView
+    case moveToVoteComplete(VoteCompleteInfo)
   }
   
   @Dependency(\.mainQueue) var mainQueue
@@ -201,7 +202,7 @@ public struct VoteCore {
             userDefaultClient.set(.isFirstVoteDone, true)
           }
           
-          // TODO: 화면 이동
+          await send(.moveToVoteComplete(voteResult))
         }
         
       case .postVoteResult(.failure):
@@ -269,6 +270,9 @@ public struct VoteCore {
         return .none
         
       case .dismissVoteView:
+        return .none
+        
+      case .moveToVoteComplete:
         return .none
       }
     }

--- a/Projects/Features/Scene/GroupDetailScene/Vote/VoteComplete/VoteCompleteCore.swift
+++ b/Projects/Features/Scene/GroupDetailScene/Vote/VoteComplete/VoteCompleteCore.swift
@@ -11,6 +11,8 @@ import Models
 
 @Reducer
 public struct VoteCompleteCore {
+  public init() {}
+  
   @ObservableState
   public struct State: Equatable {
     var voteResult: VoteCompleteInfo
@@ -36,6 +38,7 @@ public struct VoteCompleteCore {
     case setImageURLString(String)
     
     // Route Action
+    case backToGroupDetail
   }
 
   public var body: some Reducer<State, Action> {
@@ -49,10 +52,13 @@ public struct VoteCompleteCore {
           }
         }
       case .completeButtonTapped:
-        return .none
+        return .send(.backToGroupDetail)
         
       case let .setImageURLString(imageURLString):
         state.imageURLString = imageURLString
+        return .none
+        
+      case .backToGroupDetail:
         return .none
       }
     }

--- a/Projects/Features/Scene/GroupDetailScene/Vote/VoteComplete/VoteCompleteView.swift
+++ b/Projects/Features/Scene/GroupDetailScene/Vote/VoteComplete/VoteCompleteView.swift
@@ -15,7 +15,7 @@ import SwiftUI
 public struct VoteCompleteView: View {
   private let store: StoreOf<VoteCompleteCore>
 
-  init(store: StoreOf<VoteCompleteCore>) {
+  public init(store: StoreOf<VoteCompleteCore>) {
     self.store = store
   }
 

--- a/Projects/Features/Scene/MainScene/Group/GroupCore.swift
+++ b/Projects/Features/Scene/MainScene/Group/GroupCore.swift
@@ -94,7 +94,7 @@ public struct GroupCore {
     case uploadFileToPresignedURLResponse(Result<Void, Error>)
     
     public enum Delegate {
-      case headerButtonTapped
+      case headerButtonTapped(Int)
       case createEventButtonTapped
       case stabbingSuccessed
       case stabbingFailed
@@ -114,7 +114,7 @@ public struct GroupCore {
         return .none
         
       case .headerButtonTapped:
-        return .send(.delegate(.headerButtonTapped))
+        return .send(.delegate(.headerButtonTapped(state.id)))
         
       case .createEventButtonTapped:
         return .send(.delegate(.createEventButtonTapped))

--- a/Projects/Features/Scene/MainScene/GroupList/GroupListCore.swift
+++ b/Projects/Features/Scene/MainScene/GroupList/GroupListCore.swift
@@ -64,7 +64,7 @@ public struct GroupListCore {
     case moveToMyPage
     case moveToCreateGroup
     case moveToJoinGroup
-    case moveToGroupDetail
+    case moveToGroupDetail(Int)
     case moveToCreateEvent
     case moveToVote
   }
@@ -166,8 +166,8 @@ public struct GroupListCore {
       case let .groups(.element(id: _, action: .delegate(delegate))):
         return .run { send in
           switch delegate {
-          case .headerButtonTapped:
-            await send(.moveToGroupDetail)
+          case let .headerButtonTapped(groupID):
+            await send(.moveToGroupDetail(groupID))
           case .createEventButtonTapped:
             await send(.moveToCreateEvent)
           case .stabbingSuccessed:

--- a/Tuist/ProjectDescriptionHelpers/TargetDependency+extensions.swift
+++ b/Tuist/ProjectDescriptionHelpers/TargetDependency+extensions.swift
@@ -47,6 +47,7 @@ public enum TargetName: String {
   case appCoordinator = "AppCoordinator"
   case mainCoordinator = "MainCoordinator"
   case createGroupCoordinator = "CreateGroupCoordinator"
+  case groupDetailCoordinator = "GroupDetailCoordinator"
 }
 
 public enum ExternalDependency: String {


### PR DESCRIPTION
## 📌 Related Issue
- #118 

## 🚀 Description
그룹 상세 나머지 부분 기능 구현 & 코디네이터 작업까지 진행했습니다!

## ✅ Done
- [x] 그룹상세 하단 우리들의 인생네컷 GridView
- [x] 상세 이미지 뷰어
- [x] 코디네이터 작업

## 📸 Screenshot
<img width="398" alt="image" src="https://github.com/user-attachments/assets/0a74e783-2152-461c-b8de-84bdc40a8335">
<img width="401" alt="image" src="https://github.com/user-attachments/assets/f4216024-4709-4d44-af05-d832a7bea383">

## 📢 Notes
아직 짜잘한 이슈가 많긴 한데요? 다른 브랜치에서 열심히 작업 중 입니다. 많관부.
 
## 🧪 Testing(optional)
