### PR TITLE
[Fix] 어느 그룹에도 속하지 않은 사용자에게는 홈화면이 아닌 시작화면이 보여지도록 수정

### DIFF
--- a/Projects/App/Sources/RootCore.swift
+++ b/Projects/App/Sources/RootCore.swift
@@ -75,6 +75,10 @@ public struct RootCore {
         state.destination = .mainCoordinator(MainCoordinatorCore.State(routes: [.root(.home(HomeCore.State()), embedInNavigationView: true)]))
         return .none
         
+      case .destination(.presented(.login(.moveToGetStarted))):
+        state.destination = .mainCoordinator(MainCoordinatorCore.State(routes: [.root(.getStarted(.init()), embedInNavigationView: true)]))
+        return .none
+        
       case .destination:
         return .none
         

--- a/Projects/App/Sources/RootCore.swift
+++ b/Projects/App/Sources/RootCore.swift
@@ -50,6 +50,7 @@ public struct RootCore {
     case getUserInfoFromKeyChain(Result<UserInfo, Error>)
     case checkAccessToken(Result<TestInfo, Error>, userInfo: UserInfo)
     case refreshToken(Result<TokenInfo, Error>, userInfo: UserInfo)
+    case getGroupsResponse(Result<GroupsData, Error>)
     case logError(RootCoreError)
     case setDestination(Destination.State?)
   }
@@ -58,6 +59,7 @@ public struct RootCore {
   @Dependency(\.kakaoLoginClient) private var kakaoLoginClient
   @Dependency(\.keyChainClient) private var keyChainClient
   @Dependency(\.userDefaultsClient) private var userDefaultsClient
+  @Dependency(\.groupAPIClient) private var groupAPIClient
   
   public var body: some Reducer<State, Action> {
     BindingReducer()
@@ -112,8 +114,11 @@ public struct RootCore {
         
       case let .checkAccessToken(.success, userInfo):
         state.userInfo = userInfo
-        state.destination = .mainCoordinator(MainCoordinatorCore.State(routes: [.root(.home(HomeCore.State()), embedInNavigationView: true)]))
-        return .none
+        return .run { send in
+          await send(.getGroupsResponse(Result {
+            try await self.groupAPIClient.getGroups(userInfo.accessToken)
+          }))
+        }
         
       case let .checkAccessToken(.failure, userInfo):
         return .run { send in
@@ -133,7 +138,9 @@ public struct RootCore {
         return .run(
           operation: { [newUserInfo] send in
             try await keyChainClient.updateUserInfo(newUserInfo)
-            await send(.setDestination(.mainCoordinator(MainCoordinatorCore.State(routes: [.root(.home(HomeCore.State()), embedInNavigationView: true)]))))
+            await send(.getGroupsResponse(Result {
+              try await self.groupAPIClient.getGroups(newUserInfo.accessToken)
+            }))
           },
           catch: { error, send in
             await send(.setDestination(.login(LoginCore.State())))
@@ -143,6 +150,20 @@ public struct RootCore {
         
       case .refreshToken(.failure, _):
         state.destination = .login(LoginCore.State())
+        return .none
+        
+      case let .getGroupsResponse(.success(groupsData)):
+        let isMemberOfAnyGroup = !groupsData.groups.isEmpty
+        if isMemberOfAnyGroup {
+          state.destination = .mainCoordinator(MainCoordinatorCore.State(routes: [.root(.home(HomeCore.State()), embedInNavigationView: true)]))
+        } else {
+          state.destination = .mainCoordinator(MainCoordinatorCore.State(routes: [.root(.getStarted(GetStartedCore.State()), embedInNavigationView: true)]))
+        }
+        
+        return .none
+        
+      case .getGroupsResponse(.failure):
+        state.destination = .mainCoordinator(MainCoordinatorCore.State(routes: [.root(.home(HomeCore.State()), embedInNavigationView: true)]))
         return .none
         
       case let .logError(error):

--- a/Projects/Core/Common/Extensions/View+extensions.swift
+++ b/Projects/Core/Common/Extensions/View+extensions.swift
@@ -35,6 +35,10 @@ public extension View {
   func draggable(isActive: Binding<(Bool, SwipeDirection)>) -> some View {
     self.modifier(DraggableViewModifier(isActive: isActive))
   }
+  
+  func disableSwipeBack() -> some View {
+    self.modifier(DisableSwipeBackModifier())
+  }
 }
 
 fileprivate struct RoundCorners: Shape {

--- a/Projects/Core/Common/Views/DisableSwipeBackModifier.swift
+++ b/Projects/Core/Common/Views/DisableSwipeBackModifier.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 public struct DisableSwipeBackModifier: ViewModifier {
-  @State var userInteractionDisabled: Bool
+  @State private var userInteractionDisabled: Bool
   
   public init(userInteractionDisabled: Bool = false) {
     self.userInteractionDisabled = userInteractionDisabled

--- a/Projects/Core/Common/Views/DisableSwipeBackModifier.swift
+++ b/Projects/Core/Common/Views/DisableSwipeBackModifier.swift
@@ -1,0 +1,38 @@
+//
+//  DisableSwipeBackModifier.swift
+//  Common
+//
+//  Created by YangJoonHyeok on 8/15/24.
+//  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
+//
+
+import SwiftUI
+
+public struct DisableSwipeBackModifier: ViewModifier {
+  @State var userInteractionDisabled: Bool
+  
+  public init(userInteractionDisabled: Bool = false) {
+    self.userInteractionDisabled = userInteractionDisabled
+  }
+  
+  public func body(content: Content) -> some View {
+    content
+      .simultaneousGesture(
+        DragGesture()
+          .onChanged { value in
+            let isLeftToRightSwipe = value.translation.width > 0
+            if isLeftToRightSwipe {
+              userInteractionDisabled = true
+            }
+          }
+          .onEnded { value in
+            userInteractionDisabled = false
+          }
+      )
+      .overlay {
+        if userInteractionDisabled {
+          Color.clear
+        }
+      }
+  }
+}

--- a/Projects/DesignSystem/Sources/Views/Button/GabbangzipButton.swift
+++ b/Projects/DesignSystem/Sources/Views/Button/GabbangzipButton.swift
@@ -64,7 +64,7 @@ public enum ButtonType {
     case .active, .inactive:
       return DesignSystem.Colors.gray0
     case .secondary:
-      return DesignSystem.Colors.gray60
+      return DesignSystem.Colors.gray80
     }
   }
   

--- a/Projects/Features/Coordinator/CreateGroupCoordinator/CreateGroupCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/CreateGroupCoordinator/CreateGroupCoordinatorCore.swift
@@ -29,14 +29,8 @@ public struct CreateGroupCoordinatorCore {
   public var body: some Reducer<State, Action> {
     Reduce { state, action in
       switch action {
-      case .router(.routeAction(id: _, action: .createGroupStart(.moveToSetGroupName))):
-        state.routes.push(.setGroupName(.init()))
-        
       case let .router(.routeAction(id: _, action: .setGroupName(.moveToSelectKeyword(groupName)))):
         state.routes.push(.selectKeyword(.init(groupName: groupName)))
-        
-      case .router(.routeAction(id: _, action: .setGroupName(.backToCreateGroupStart))):
-        state.routes.pop()
         
       case let .router(.routeAction(id: _, action: .selectKeyword(.moveToSelectGroupPhoto(groupName, selectedKeyword)))):
         state.routes.push(.selectGroupPhoto(.init(groupName: groupName, keyword: selectedKeyword)))

--- a/Projects/Features/Coordinator/CreateGroupCoordinator/CreateGroupCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/CreateGroupCoordinator/CreateGroupCoordinatorCore.swift
@@ -29,17 +29,17 @@ public struct CreateGroupCoordinatorCore {
   public var body: some Reducer<State, Action> {
     Reduce { state, action in
       switch action {
-      case let .router(.routeAction(id: _, action: .setGroupName(.moveToSelectKeyword(groupName)))):
-        state.routes.push(.selectKeyword(.init(groupName: groupName)))
+      case let .router(.routeAction(id: _, action: .setGroupName(.moveToSelectKeyword(groupName, isFromGetStarted)))):
+        state.routes.push(.selectKeyword(.init(groupName: groupName, isFromGetStarted: isFromGetStarted)))
         
-      case let .router(.routeAction(id: _, action: .selectKeyword(.moveToSelectGroupPhoto(groupName, selectedKeyword)))):
-        state.routes.push(.selectGroupPhoto(.init(groupName: groupName, keyword: selectedKeyword)))
+      case let .router(.routeAction(id: _, action: .selectKeyword(.moveToSelectGroupPhoto(groupName, selectedKeyword, isFromGetStarted)))):
+        state.routes.push(.selectGroupPhoto(.init(groupName: groupName, keyword: selectedKeyword, isFromGetStarted: isFromGetStarted)))
         
       case .router(.routeAction(id: _, action: .selectKeyword(.backToSetGroupName))):
         state.routes.pop()
         
-      case let .router(.routeAction(id: _, action: .selectGroupPhoto(.moveToCreateGroupCompletion(createdGroupInfo)))):
-        state.routes.push(.createGroupCompletion(.init(createdGroupInfo: createdGroupInfo)))
+      case let .router(.routeAction(id: _, action: .selectGroupPhoto(.moveToCreateGroupCompletion(createdGroupInfo, isFromGetStarted)))):
+        state.routes.push(.createGroupCompletion(.init(createdGroupInfo: createdGroupInfo, isFromGetStarted: isFromGetStarted)))
         break
         
       case .router(.routeAction(id: _, action: .selectGroupPhoto(.backToSelectKeyword))):

--- a/Projects/Features/Coordinator/CreateGroupCoordinator/CreateGroupCoordinatorView.swift
+++ b/Projects/Features/Coordinator/CreateGroupCoordinator/CreateGroupCoordinatorView.swift
@@ -22,8 +22,6 @@ public struct CreateGroupCoordinatorView: View {
     TCARouter(store.scope(state: \.routes, action: \.router)) { screen in
       Group {
         switch screen.case {
-        case let .createGroupStart(store):
-          CreateGroupStartView(store: store)
         case let .setGroupName(store):
           SetGroupNameView(store: store)
         case let .selectKeyword(store):

--- a/Projects/Features/Coordinator/CreateGroupCoordinator/CreateGroupScreen.swift
+++ b/Projects/Features/Coordinator/CreateGroupCoordinator/CreateGroupScreen.swift
@@ -12,7 +12,6 @@ import TCACoordinators
 
 @Reducer(state: .equatable)
 public enum CreateGroupScreen {
-  case createGroupStart(CreateGroupStartCore)
   case setGroupName(SetGroupNameCore)
   case selectKeyword(SelectKeywordCore)
   case selectGroupPhoto(SelectGroupPhotoCore)

--- a/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorCore.swift
@@ -47,6 +47,12 @@ public struct MainCoordinatorCore {
       case .router(.routeAction(id: _, action: .joinGroup(.backToHome))):
         state.routes.pop()
         
+      case .router(.routeAction(id: _, action: .joinGroup(.backToGetStarted))):
+        state.routes.pop()
+        
+      case .router(.routeAction(id: _, action: .joinGroup(.goToHome))):
+        state.routes.push(.home(.init()))
+        
       case .router(.routeAction(id: _, action: .createGroupCoordinator(.router(.routeAction(id: _, action: .setGroupName(.backToHome)))))):
         state.routes.dismiss()
         

--- a/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorCore.swift
@@ -36,7 +36,7 @@ public struct MainCoordinatorCore {
         state.routes.pop()
         
       case .router(.routeAction(id: _, action: .home(.moveToCreateGroup))):
-        state.routes.presentCover(.createGroupCoordinator(.init(routes: [.root(.createGroupStart(.init()), embedInNavigationView: true)])))
+        state.routes.presentCover(.createGroupCoordinator(.init(routes: [.root(.setGroupName(.init(isFromGetStarted: false)), embedInNavigationView: true)])))
         
       case .router(.routeAction(id: _, action: .home(.moveToCreateEvent))):
         state.routes.push(.createEvent(.init()))
@@ -61,6 +61,12 @@ public struct MainCoordinatorCore {
         
       case .router(.routeAction(id: _, action: .createEvent(.moveToHomeWithEvent))):
         state.routes.pop()
+        
+      case .router(.routeAction(id: _, action: .getStarted(.moveToJoinGroup))):
+        state.routes.push(.joinGroup(.init()))
+        
+      case .router(.routeAction(id: _, action: .getStarted(.moveToSetGroupName))):
+        state.routes.push(.createGroupCoordinator(.init(routes: [.root(.setGroupName(.init(isFromGetStarted: true)), embedInNavigationView: true)])))
         
       default:
         break

--- a/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorCore.swift
@@ -42,13 +42,22 @@ public struct MainCoordinatorCore {
         state.routes.push(.createEvent(.init()))
         
       case .router(.routeAction(id: _, action: .home(.moveToJoinGroup))):
-        state.routes.push(.joinGroup(.init()))
+        state.routes.push(.joinGroup(.init(isFromGetStarted: false)))
         
       case .router(.routeAction(id: _, action: .joinGroup(.backToHome))):
         state.routes.pop()
         
+      case .router(.routeAction(id: _, action: .createGroupCoordinator(.router(.routeAction(id: _, action: .setGroupName(.backToHome)))))):
+        state.routes.dismiss()
+        
+      case .router(.routeAction(id: _, action: .createGroupCoordinator(.router(.routeAction(id: _, action: .setGroupName(.backToGetStarted)))))):
+        state.routes.pop()
+        
       case .router(.routeAction(id: _, action: .createGroupCoordinator(.router(.routeAction(id: _, action: .createGroupCompletion(.backToHome)))))):
         state.routes.dismiss()
+        
+      case .router(.routeAction(id: _, action: .createGroupCoordinator(.router(.routeAction(id: _, action: .createGroupCompletion(.goToHome)))))):
+        state.routes.push(.home(.init()))
         
       case let .router(.routeAction(id: _, action: .home(.moveToGroupDetail(groupID)))):
         state.routes.push(.groupDetailCoordinator(.init(routes: [.root(.groupDetail(.init(groupID: groupID)))])))
@@ -63,7 +72,7 @@ public struct MainCoordinatorCore {
         state.routes.pop()
         
       case .router(.routeAction(id: _, action: .getStarted(.moveToJoinGroup))):
-        state.routes.push(.joinGroup(.init()))
+        state.routes.push(.joinGroup(.init(isFromGetStarted: true)))
         
       case .router(.routeAction(id: _, action: .getStarted(.moveToSetGroupName))):
         state.routes.push(.createGroupCoordinator(.init(routes: [.root(.setGroupName(.init(isFromGetStarted: true)), embedInNavigationView: true)])))

--- a/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorView.swift
+++ b/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorView.swift
@@ -37,6 +37,8 @@ public struct MainCoordinatorView: View {
         JoinGroupView(store: store)
       case let .groupDetailCoordinator(store):
         GroupDetailCoordinatorView(store: store)
+      case let .getStarted(store):
+        GetStartedView(store: store)
       }
     }
   }

--- a/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorView.swift
+++ b/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorView.swift
@@ -24,22 +24,25 @@ public struct MainCoordinatorView: View {
   
   public var body: some View {
     TCARouter(store.scope(state: \.routes, action: \.router)) { screen in
-      switch screen.case {
-      case let .createGroupCoordinator(store):
-        CreateGroupCoordinatorView(store: store)
-      case let .createEvent(store):
-        CreateEventView(store: store)
-      case let .myPage(store):
-        MyPageView(store: store)
-      case let .home(store):
-        HomeView(store: store)
-      case let .joinGroup(store):
-        JoinGroupView(store: store)
-      case let .groupDetailCoordinator(store):
-        GroupDetailCoordinatorView(store: store)
-      case let .getStarted(store):
-        GetStartedView(store: store)
+      Group {
+        switch screen.case {
+        case let .createGroupCoordinator(store):
+          CreateGroupCoordinatorView(store: store)
+        case let .createEvent(store):
+          CreateEventView(store: store)
+        case let .myPage(store):
+          MyPageView(store: store)
+        case let .home(store):
+          HomeView(store: store)
+        case let .joinGroup(store):
+          JoinGroupView(store: store)
+        case let .groupDetailCoordinator(store):
+          GroupDetailCoordinatorView(store: store)
+        case let .getStarted(store):
+          GetStartedView(store: store)
+        }
       }
+      .toolbar(.hidden)
     }
   }
 }

--- a/Projects/Features/Coordinator/MainCoordinator/MainScreen.swift
+++ b/Projects/Features/Coordinator/MainCoordinator/MainScreen.swift
@@ -22,4 +22,5 @@ public enum MainScreen {
   case home(HomeCore)
   case joinGroup(JoinGroupCore)
   case groupDetailCoordinator(GroupDetailCoordinatorCore)
+  case getStarted(GetStartedCore)
 }

--- a/Projects/Features/Scene/CreateGroupScene/CreateGroupCompletion/CreateGroupCompletionCore.swift
+++ b/Projects/Features/Scene/CreateGroupScene/CreateGroupCompletion/CreateGroupCompletionCore.swift
@@ -21,15 +21,18 @@ public struct CreateGroupCompletionCore {
     var createdGroupInfo: CreatedGroupInfo
     var imageURLString: String
     var toastPresented: Bool
+    var isFromGetStarted: Bool
     
     public init(
       createdGroupInfo: CreatedGroupInfo,
       imageURLString: String = "",
-      toastPresented: Bool = false
+      toastPresented: Bool = false,
+      isFromGetStarted: Bool
     ) {
       self.createdGroupInfo = createdGroupInfo
       self.imageURLString = imageURLString
       self.toastPresented = toastPresented
+      self.isFromGetStarted = isFromGetStarted
     }
   }
 
@@ -45,6 +48,7 @@ public struct CreateGroupCompletionCore {
     
     // Route Action
     case backToHome
+    case goToHome
   }
   
   @Dependency(\.bundleClient) var bundleClient
@@ -62,7 +66,7 @@ public struct CreateGroupCompletionCore {
         }
       
       case .completeButtonTapped:
-        return .send(.backToHome)
+        return .send(state.isFromGetStarted ? .goToHome : .backToHome)
         
       case .copyLinkButtonTapped:
         state.toastPresented = true
@@ -82,6 +86,8 @@ public struct CreateGroupCompletionCore {
       case .backToHome:
         return .none
         
+      case .goToHome:
+        return .none
       }
     }
   }

--- a/Projects/Features/Scene/CreateGroupScene/CreateGroupCompletion/CreateGroupCompletionView.swift
+++ b/Projects/Features/Scene/CreateGroupScene/CreateGroupCompletion/CreateGroupCompletionView.swift
@@ -94,7 +94,8 @@ public struct CreateGroupCompletionView: View {
           groupImageURL: "pic/9c8f3f24-6ed2-4a2e-8af5-52aeff93b230.jpeg",
           invitationCode: "ttat"
         ),
-        imageURLString: "https://pic-api-bucket.s3.ap-northeast-2.amazonaws.com/pic/9c8f3f24-6ed2-4a2e-8af5-52aeff93b230.jpeg"
+        imageURLString: "https://pic-api-bucket.s3.ap-northeast-2.amazonaws.com/pic/9c8f3f24-6ed2-4a2e-8af5-52aeff93b230.jpeg",
+        isFromGetStarted: true
       ),
       reducer: CreateGroupCompletionCore.init
     )

--- a/Projects/Features/Scene/CreateGroupScene/GetStartedView/GetStartedCore.swift
+++ b/Projects/Features/Scene/CreateGroupScene/GetStartedView/GetStartedCore.swift
@@ -1,5 +1,5 @@
 //
-//  CreateGroupStartCore.swift
+//  GetStartedCore.swift
 //  CreateGroup
 //
 //  Created by YangJoonHyeok on 7/9/24.
@@ -9,7 +9,7 @@
 import ComposableArchitecture
 
 @Reducer
-public struct CreateGroupStartCore {
+public struct GetStartedCore {
   public init() {}
   
   public struct State: Equatable {

--- a/Projects/Features/Scene/CreateGroupScene/GetStartedView/GetStartedView.swift
+++ b/Projects/Features/Scene/CreateGroupScene/GetStartedView/GetStartedView.swift
@@ -1,5 +1,5 @@
 //
-//  CreateGroupStartView.swift
+//  GetStartedView.swift
 //  CreateGroup
 //
 //  Created by YangJoonHyeok on 7/9/24.
@@ -10,10 +10,10 @@ import ComposableArchitecture
 import DesignSystem
 import SwiftUI
 
-public struct CreateGroupStartView: View {
-  private let store: StoreOf<CreateGroupStartCore>
+public struct GetStartedView: View {
+  private let store: StoreOf<GetStartedCore>
 
-  public init(store: StoreOf<CreateGroupStartCore>) {
+  public init(store: StoreOf<GetStartedCore>) {
     self.store = store
   }
 
@@ -55,10 +55,10 @@ public struct CreateGroupStartView: View {
 }
 
 #Preview {
-  CreateGroupStartView(
+  GetStartedView(
     store: Store(
       initialState: .init(),
-      reducer: CreateGroupStartCore.init
+      reducer: GetStartedCore.init
     )
   )
 }

--- a/Projects/Features/Scene/CreateGroupScene/SelectGroupPhoto/SelectGroupPhotoCore.swift
+++ b/Projects/Features/Scene/CreateGroupScene/SelectGroupPhoto/SelectGroupPhotoCore.swift
@@ -24,6 +24,7 @@ public struct SelectGroupPhotoCore {
     var keyword: GroupData.Keyword
     var nextButtonType: ButtonType
     var selectedPhotosInfo: [PhotoInfo]
+    var isFromGetStarted: Bool
 
     public init(
       userInfo: @autoclosure () -> UserInfo = .defaultValue,
@@ -31,7 +32,8 @@ public struct SelectGroupPhotoCore {
       groupName: String,
       keyword: GroupData.Keyword,
       nextButtonType: ButtonType = .inactive,
-      selectedPhotosInfo: [PhotoInfo] = []
+      selectedPhotosInfo: [PhotoInfo] = [],
+      isFromGetStarted: Bool
     ) {
       self._userInfo = Shared(wrappedValue: userInfo(), .inMemory("userInfo"))
       self._isHomeUpdated = Shared(wrappedValue: isHomeUpdated(), .inMemory("isHomeUpdated"))
@@ -39,6 +41,7 @@ public struct SelectGroupPhotoCore {
       self.nextButtonType = nextButtonType
       self.keyword = keyword
       self.selectedPhotosInfo = selectedPhotosInfo
+      self.isFromGetStarted = isFromGetStarted
     }
   }
 
@@ -54,7 +57,7 @@ public struct SelectGroupPhotoCore {
     case createGroupResponse(Result<CreatedGroupInfo, Error>)
     
     // Route Action
-    case moveToCreateGroupCompletion(CreatedGroupInfo)
+    case moveToCreateGroupCompletion(createdGroupInfo: CreatedGroupInfo, isFromGetStarted: Bool)
     case backToSelectKeyword
   }
   
@@ -129,7 +132,7 @@ public struct SelectGroupPhotoCore {
         
       case let .createGroupResponse(.success(createdGroupInfo)):
         state.isHomeUpdated = true
-        return .send(.moveToCreateGroupCompletion(createdGroupInfo))
+        return .send(.moveToCreateGroupCompletion(createdGroupInfo: createdGroupInfo, isFromGetStarted: state.isFromGetStarted))
         
       case let .createGroupResponse(.failure(error)):
         return .run { send in

--- a/Projects/Features/Scene/CreateGroupScene/SelectGroupPhoto/SelectGroupPhotoView.swift
+++ b/Projects/Features/Scene/CreateGroupScene/SelectGroupPhoto/SelectGroupPhotoView.swift
@@ -107,7 +107,7 @@ extension SelectGroupPhotoView {
 #Preview {
   SelectGroupPhotoView(
     store: Store(
-      initialState: .init(groupName: "그룹명열글자입니다요", keyword: .school),
+      initialState: .init(groupName: "그룹명열글자입니다요", keyword: .school, isFromGetStarted: true),
       reducer: SelectGroupPhotoCore.init
     )
   )

--- a/Projects/Features/Scene/CreateGroupScene/SelectKeyword/SelectKeywordCore.swift
+++ b/Projects/Features/Scene/CreateGroupScene/SelectKeyword/SelectKeywordCore.swift
@@ -24,6 +24,7 @@ public struct SelectKeywordCore {
     var networkKeywordButtonSelected: Bool
     var exerciseKeywordButtonSelected: Bool
     var hobbyKeywordButtonSelected: Bool
+    var isFromGetStarted: Bool
     
     public init(
       groupName: String,
@@ -34,7 +35,8 @@ public struct SelectKeywordCore {
       littleMoimKeywordButtonSelected: Bool = false,
       networkKeywordButtonSelected: Bool = false,
       exerciseKeywordButtonSelected: Bool = false,
-      hobbyKeywordButtonSelected: Bool = false
+      hobbyKeywordButtonSelected: Bool = false,
+      isFromGetStarted: Bool
     ) {
       self.groupName = groupName
       self.selectedKeyword = selectedKeyword
@@ -45,6 +47,7 @@ public struct SelectKeywordCore {
       self.networkKeywordButtonSelected = networkKeywordButtonSelected
       self.exerciseKeywordButtonSelected = exerciseKeywordButtonSelected
       self.hobbyKeywordButtonSelected = hobbyKeywordButtonSelected
+      self.isFromGetStarted = isFromGetStarted
     }
   }
 
@@ -58,7 +61,7 @@ public struct SelectKeywordCore {
     case updateKeywordSelection(keyword: GroupData.Keyword, isSelected: Bool)
     
     // Route Action
-    case moveToSelectGroupPhoto(String, GroupData.Keyword)
+    case moveToSelectGroupPhoto(groupName: String, keyword: GroupData.Keyword, isFromGetStarted: Bool)
     case backToSetGroupName
   }
 
@@ -66,7 +69,7 @@ public struct SelectKeywordCore {
     Reduce { state, action in
       switch action {
       case .nextButtonTapped:
-        return .send(.moveToSelectGroupPhoto(state.groupName, state.selectedKeyword))
+        return .send(.moveToSelectGroupPhoto(groupName: state.groupName, keyword: state.selectedKeyword, isFromGetStarted: state.isFromGetStarted))
         
       case .backButtonTapped:
         return .send(.backToSetGroupName)

--- a/Projects/Features/Scene/CreateGroupScene/SelectKeyword/SelectKeywordView.swift
+++ b/Projects/Features/Scene/CreateGroupScene/SelectKeyword/SelectKeywordView.swift
@@ -104,7 +104,7 @@ public struct SelectKeywordView: View {
 #Preview {
   SelectKeywordView(
     store: Store(
-      initialState: .init(groupName: "test"),
+      initialState: .init(groupName: "test", isFromGetStarted: true),
       reducer: SelectKeywordCore.init
     )
   )

--- a/Projects/Features/Scene/CreateGroupScene/SetGroupName/SetGroupNameCore.swift
+++ b/Projects/Features/Scene/CreateGroupScene/SetGroupName/SetGroupNameCore.swift
@@ -17,13 +17,16 @@ public struct SetGroupNameCore {
   public struct State: Equatable {
     var text: String
     var nextButtonType: ButtonType
+    var isFromGetStarted: Bool
     
     public init(
       text: String = "",
-      nextButtonType: ButtonType = .inactive
+      nextButtonType: ButtonType = .inactive,
+      isFromGetStarted: Bool
     ) {
       self.text = text
       self.nextButtonType = nextButtonType
+      self.isFromGetStarted = isFromGetStarted
     }
   }
   

--- a/Projects/Features/Scene/CreateGroupScene/SetGroupName/SetGroupNameCore.swift
+++ b/Projects/Features/Scene/CreateGroupScene/SetGroupName/SetGroupNameCore.swift
@@ -40,7 +40,9 @@ public struct SetGroupNameCore {
     case setNextButtonType(ButtonType)
     
     // Route Action
-    case moveToSelectKeyword(String)
+    case moveToSelectKeyword(groupName: String, isFromGetStarted: Bool)
+    case backToHome
+    case backToGetStarted
   }
   
   public var body: some Reducer<State, Action> {
@@ -58,16 +60,26 @@ public struct SetGroupNameCore {
         }
         
       case .nextButtonTapped:
-        return .send(.moveToSelectKeyword(state.text))
+        return .send(.moveToSelectKeyword(groupName: state.text, isFromGetStarted: state.isFromGetStarted))
         
       case .backButtonTapped:
-        return .none
+        if state.isFromGetStarted {
+          return .send(.backToGetStarted)
+        } else {
+          return .send(.backToHome)
+        }
         
       case let .setNextButtonType(value):
         state.nextButtonType = value
         return .none
         
       case .moveToSelectKeyword:
+        return .none
+        
+      case .backToHome:
+        return .none
+        
+      case .backToGetStarted:
         return .none
       }
     }

--- a/Projects/Features/Scene/CreateGroupScene/SetGroupName/SetGroupNameCore.swift
+++ b/Projects/Features/Scene/CreateGroupScene/SetGroupName/SetGroupNameCore.swift
@@ -38,7 +38,6 @@ public struct SetGroupNameCore {
     
     // Route Action
     case moveToSelectKeyword(String)
-    case backToCreateGroupStart
   }
   
   public var body: some Reducer<State, Action> {
@@ -59,16 +58,13 @@ public struct SetGroupNameCore {
         return .send(.moveToSelectKeyword(state.text))
         
       case .backButtonTapped:
-        return .send(.backToCreateGroupStart)
+        return .none
         
       case let .setNextButtonType(value):
         state.nextButtonType = value
         return .none
         
       case .moveToSelectKeyword:
-        return .none
-        
-      case .backToCreateGroupStart:
         return .none
       }
     }

--- a/Projects/Features/Scene/CreateGroupScene/SetGroupName/SetGroupNameView.swift
+++ b/Projects/Features/Scene/CreateGroupScene/SetGroupName/SetGroupNameView.swift
@@ -61,7 +61,7 @@ public struct SetGroupNameView: View {
 #Preview {
   SetGroupNameView(
     store: Store(
-      initialState: .init(),
+      initialState: .init(isFromGetStarted: true),
       reducer: SetGroupNameCore.init
     )
   )

--- a/Projects/Features/Scene/LoginScene/Login/LoginCore.swift
+++ b/Projects/Features/Scene/LoginScene/Login/LoginCore.swift
@@ -155,8 +155,7 @@ public struct LoginCore {
         return .send(isMemberOfAnyGroup ? .moveToHome : .moveToGetStarted)
         
       case .getGroupsResponse(.failure):
-        // TODO: - 서버의 에러 메시지 형식 및 에러 수집 방식에 대한 논의 후 수정
-        return .none
+        return .send(.moveToHome)
         
       case let .showError(isPresented):
         state.isPresented = isPresented

--- a/Projects/Features/Scene/LoginScene/Login/LoginCore.swift
+++ b/Projects/Features/Scene/LoginScene/Login/LoginCore.swift
@@ -49,17 +49,20 @@ public struct LoginCore {
     case checkUserInformationResponse(Result<User, Error>)
     case loginResponse(Result<PICUserInfo, Error>)
     case saveUserInfoToKeychain(Result<Void, Error>)
+    case getGroupsResponse(Result<GroupsData, Error>)
     case showError(Bool)
     case logError(LoginCoreError)
     
     // Route Action
     case moveToHome
+    case moveToGetStarted
   }
   
   @Dependency(\.kakaoLoginClient) private var kakaoLoginClient
   @Dependency(\.authAPIClient) private var authAPIClient
   @Dependency(\.keyChainClient) private var keyChainClient
   @Dependency(\.userDefaultsClient) private var userDefaultsClient
+  @Dependency(\.groupAPIClient) private var groupAPIClient
   
   public var body: some Reducer<State, Action> {
     BindingReducer()
@@ -128,7 +131,9 @@ public struct LoginCore {
         state.userInfo = userInfo
         return .run { send in
           await send(.saveUserInfoToKeychain(Result { try await self.keyChainClient.createUserInfo(userInfo) }))
-          await send(.moveToHome)
+          await send(.getGroupsResponse(Result {
+            try await self.groupAPIClient.getGroups(userInfo.accessToken)
+          }))
         }
         
       case .loginResponse(.failure):
@@ -145,6 +150,14 @@ public struct LoginCore {
           await send(.logError(LoginCoreError(code: .failToSaveUserInfoToKeychain)))
         }
         
+      case let .getGroupsResponse(.success(groupsData)):
+        let isMemberOfAnyGroup = !groupsData.groups.isEmpty
+        return .send(isMemberOfAnyGroup ? .moveToHome : .moveToGetStarted)
+        
+      case .getGroupsResponse(.failure):
+        // TODO: - 서버의 에러 메시지 형식 및 에러 수집 방식에 대한 논의 후 수정
+        return .none
+        
       case let .showError(isPresented):
         state.isPresented = isPresented
         return .none
@@ -155,6 +168,9 @@ public struct LoginCore {
         }
         
       case .moveToHome:
+        return .none
+        
+      case .moveToGetStarted:
         return .none
       }
     }

--- a/Projects/Features/Scene/MainScene/GetStartedView/GetStartedCore.swift
+++ b/Projects/Features/Scene/MainScene/GetStartedView/GetStartedCore.swift
@@ -33,7 +33,7 @@ public struct GetStartedCore {
         return .send(.moveToSetGroupName)
         
       case .inviteCodeButtonTapped:
-        return .none
+        return .send(.moveToJoinGroup)
         
       case .moveToSetGroupName:
         return .none

--- a/Projects/Features/Scene/MainScene/GetStartedView/GetStartedCore.swift
+++ b/Projects/Features/Scene/MainScene/GetStartedView/GetStartedCore.swift
@@ -1,6 +1,6 @@
 //
 //  GetStartedCore.swift
-//  CreateGroup
+//  Main
 //
 //  Created by YangJoonHyeok on 7/9/24.
 //  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
@@ -19,9 +19,11 @@ public struct GetStartedCore {
   public enum Action {
     // View Action
     case createGroupButtonTapped
+    case inviteCodeButtonTapped
     
     // Route Action
     case moveToSetGroupName
+    case moveToJoinGroup
   }
 
   public var body: some Reducer<State, Action> {
@@ -30,7 +32,13 @@ public struct GetStartedCore {
       case .createGroupButtonTapped:
         return .send(.moveToSetGroupName)
         
+      case .inviteCodeButtonTapped:
+        return .none
+        
       case .moveToSetGroupName:
+        return .none
+        
+      case .moveToJoinGroup:
         return .none
       }
     }

--- a/Projects/Features/Scene/MainScene/GetStartedView/GetStartedView.swift
+++ b/Projects/Features/Scene/MainScene/GetStartedView/GetStartedView.swift
@@ -1,6 +1,6 @@
 //
 //  GetStartedView.swift
-//  CreateGroup
+//  Main
 //
 //  Created by YangJoonHyeok on 7/9/24.
 //  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
@@ -41,6 +41,13 @@ public struct GetStartedView: View {
           .foregroundStyle(DesignSystem.Colors.gray60)
           .padding(.bottom, 16)
         
+        GabbangzipBottomButton(
+          type: .secondary,
+          title: "초대코드 입력하기",
+          action: { store.send(.inviteCodeButtonTapped) }
+        )
+        .padding(.horizontal, 16)
+        .padding(.bottom, 12)
         
         GabbangzipBottomButton(
           type: .active,

--- a/Projects/Features/Scene/MainScene/Home/HomeView.swift
+++ b/Projects/Features/Scene/MainScene/Home/HomeView.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
 //
 
+import Common
 import ComposableArchitecture
 import DesignSystem
 import Models
@@ -35,6 +36,7 @@ public struct HomeView: View {
       }
     }
     .background(DesignSystem.Colors.gray0)
+    .disableSwipeBack()
     .onAppear { store.send(.onAppear) }
     .toast(
       isPresented: $store.toastPresented.sending(\.toastPresentedChanged),

--- a/Projects/Features/Scene/MainScene/JoinGroup/JoinGroupCore.swift
+++ b/Projects/Features/Scene/MainScene/JoinGroup/JoinGroupCore.swift
@@ -20,6 +20,7 @@ public struct JoinGroupCore {
     @Shared var userInfo: UserInfo
     var text: String
     var toastPresented: Bool
+    var isFromGetStarted: Bool
     var nextButtonType: ButtonType {
       text.isEmpty ? .inactive : .active
     }
@@ -27,11 +28,13 @@ public struct JoinGroupCore {
     public init(
       userInfo: @autoclosure () -> UserInfo = .defaultValue,
       text: String = "",
-      toastPresented: Bool = false
+      toastPresented: Bool = false,
+      isFromGetStarted: Bool
     ) {
       self._userInfo = Shared(wrappedValue: userInfo(), .inMemory("userInfo"))
       self.text = text
       self.toastPresented = toastPresented
+      self.isFromGetStarted = isFromGetStarted
     }
   }
   
@@ -48,6 +51,8 @@ public struct JoinGroupCore {
     
     // Route Action
     case backToHome
+    case backToGetStarted
+    case goToHome
   }
   
   @Dependency(\.groupAPIClient) var groupAPIClient
@@ -56,7 +61,7 @@ public struct JoinGroupCore {
     Reduce { state, action in
       switch action {
       case .backButtonTapped:
-        return .send(.backToHome)
+        return .send(state.isFromGetStarted ? .backToGetStarted : .backToHome)
         
       case let .textChanged(text):
         state.text = text
@@ -74,7 +79,7 @@ public struct JoinGroupCore {
         return .none
         
       case .joinGroupResponse(.success):
-        return .send(.backToHome)
+        return .send(state.isFromGetStarted ? .goToHome : .backToHome)
         
       case let .joinGroupResponse(.failure(error)):
         return .run { send in
@@ -83,6 +88,12 @@ public struct JoinGroupCore {
         }
         
       case .backToHome:
+        return .none
+        
+      case .backToGetStarted:
+        return .none
+        
+      case .goToHome:
         return .none
       }
     }

--- a/Projects/Features/Scene/MainScene/JoinGroup/JoinGroupView.swift
+++ b/Projects/Features/Scene/MainScene/JoinGroup/JoinGroupView.swift
@@ -57,7 +57,7 @@ public struct JoinGroupView: View {
 #Preview {
   JoinGroupView(
     store: Store(
-      initialState: .init(),
+      initialState: .init(isFromGetStarted: true),
       reducer: JoinGroupCore.init
     )
   )


### PR DESCRIPTION
## 📌 Related Issue
- #125 

## 🚀 Description
- 어느 그룹에도 속하지 않은 사용자에게는 홈화면이 아닌 시작화면이 보여지도록 수정

## ✅ TODO
### 속한 그룹이 없을 경우 보여지는 화면 다르도록 로직 수정
- [x] Login에서 getGroups API 호출하여 속한 그룹 여부 확인
- [x] Login에서 속한 그룹 여부에 따라 이동할 화면에 대한 액션 추가
- [x] JoinGroup에 그룹이 없는 케이스에 대한 플래그 추가
- [x] JoinGroup에서 속한 그룹 여부에 따라 이동할 화면에 대한 액션 추가
- [x] SetGroupName 및 그 이후의 화면들에 그룹이 없는 케이스에 대한 플래그 추가
- [x] SetGroupName 및 CreateGroupCompletionView에서 속한 그룹 여부에 따라 이동할 화면에 대한 액션 추가
- [x] Root에서 getGroups API 호출하여 속한 그룹 여부 확인(자동 로그인)
- [x] Root에서 속한 그룹 여부에 따라 이동할 화면에 대한 액션 추가
- [x] GetStarted에서 CreateGroupCoordinator 혹은 JoinGroup으로 이동하는 분기 로직 구현
- [x] 뒤로가기 스와이프 막는 메서드 추가 및 홈 화면에 적용

### 코디네이터 수정
- [x] CreateGroupStart를 CreateGroupCoordinator에서 제거
- [x] CreateGroupStart를 GetStarted로 이름 변경 후 MainScene 및 MainCoordinator로 이동
- [x] CreateGroupCoordinator의 root는 SetGroupName으로 수정
- [x] MainCoordinator에서 getStarted를 추가하고 JoinGroup, SetGroupName 이동 로직 구현
- [x] isFromGetStarted 값을 넘겨주는 로직 코디네이터 내에 추가

## 📸 Screenshot(optional)


https://github.com/user-attachments/assets/07ded73b-1d3c-4268-820b-bdaed6119999


https://github.com/user-attachments/assets/8d59b090-71ad-4174-98ac-c3d3431afaa8


## 📢 Notes
 
## 🧪 Testing(optional)
