### PR TITLE
[Feat] CreateEvent API 연동, FCM 토큰 API 연동, CreateEvent View 수정

### DIFF
--- a/Projects/App/Sources/AppDelegateCore.swift
+++ b/Projects/App/Sources/AppDelegateCore.swift
@@ -75,14 +75,6 @@ struct AppDelegateCore {
           await firebaseClient.configure()
         }
         
-      case .checkRegisterToken:
-        return .run { send in
-          let token = try await firebaseClient.checkRegistrationToken()
-          await send(.logFCMDescription(token))
-        } catch: { _, send in
-          await send(.logError(AppDelegateCoreError(code: .failToGetRegisterToken)))
-        }
-        
       case .runFirebaseAutoInitialization:
         return .run { send in
           await firebaseClient.runAutoInitialization()
@@ -90,7 +82,7 @@ struct AppDelegateCore {
         
       case let .getDeviceToken(deviceToken):
         return .run { send in
-          await firebaseClient.getDeviceToken(deviceToken)
+          await firebaseClient.setDeviceToken(deviceToken)
         }
         
       case .setupNotificationCenter:

--- a/Projects/App/Sources/AppDelegateCore.swift
+++ b/Projects/App/Sources/AppDelegateCore.swift
@@ -20,17 +20,16 @@ struct AppDelegateCore {
   enum Action {
     case didFinishLaunching
     
-    // KakaoSDK Setting
+    // KakaoSDK
     case setupKakaoSDK
     
-    // Firebase Setting
+    // Firebase
     case setupFirebase
     case configureFirebase
-    case checkRegisterToken
     case runFirebaseAutoInitialization
     case getDeviceToken(Data)
     
-    // NotificationCenter Setting
+    // NotificationCenter
     case setupNotificationCenter
     case configureNotificationCenterDelegate
     case requestNotificationCenterAuthorization
@@ -38,14 +37,13 @@ struct AppDelegateCore {
     case authorizationStatusResposne(Result<Void, Error>)
     
     case logError(AppDelegateCoreError)
-    case logFCMDescription(String)
   }
   
-  @Dependency(\.userNotificationClient) private var userNotificationClient
   @Dependency(\.bundleClient) private var bundleClient
-  @Dependency(\.kakaoLoginClient) private var kakaoLoginClient
   @Dependency(\.firebaseClient) private var firebaseClient
+  @Dependency(\.kakaoLoginClient) private var kakaoLoginClient
   @Dependency(\.uiApplicationClient) private var uiApplicationClient
+  @Dependency(\.userNotificationClient) private var userNotificationClient
   
   var body: some Reducer<State, Action> {
     Reduce { state, action in
@@ -69,7 +67,6 @@ struct AppDelegateCore {
         return .run { send in
           await send(.configureFirebase)
           await send(.setupNotificationCenter)
-          await send(.checkRegisterToken)
           await send(.runFirebaseAutoInitialization)
         }
         
@@ -147,11 +144,6 @@ struct AppDelegateCore {
         return .run { send in
           logger.error("AppDelegateCore Error: \(String(describing: error))")
         }
-        
-      case let .logFCMDescription(description):
-        return .run { send in
-          logger.debug("FCM registration token: \(String(describing: description))")
-        }
       }
     }
   }
@@ -165,7 +157,6 @@ public struct AppDelegateCoreError: GabbangzipError {
   
   public enum Code: Int {
     case failToStringTypeCasting
-    case failToGetRegisterToken
     case failToGetAuthorizationStatusResposne
   }
 }

--- a/Projects/App/Sources/RootCore.swift
+++ b/Projects/App/Sources/RootCore.swift
@@ -144,6 +144,7 @@ public struct RootCore {
       case let .setDestination(destination):
         state.destination = destination
         return .none
+        
       case let .logError(error):
         return .run { send in
           logger.error("RootCore Error: \(error)")

--- a/Projects/App/Sources/RootCore.swift
+++ b/Projects/App/Sources/RootCore.swift
@@ -50,8 +50,8 @@ public struct RootCore {
     case getUserInfoFromKeyChain(Result<UserInfo, Error>)
     case checkAccessToken(Result<TestInfo, Error>, userInfo: UserInfo)
     case refreshToken(Result<TokenInfo, Error>, userInfo: UserInfo)
-    case logError(RootCoreError)
     case setDestination(Destination.State?)
+    case logError(RootCoreError)
   }
   
   @Dependency(\.authAPIClient) private var authAPIClient
@@ -141,14 +141,13 @@ public struct RootCore {
         state.destination = .login(LoginCore.State())
         return .none
         
+      case let .setDestination(destination):
+        state.destination = destination
+        return .none
       case let .logError(error):
         return .run { send in
           logger.error("RootCore Error: \(error)")
         }
-        
-      case let .setDestination(destination):
-        state.destination = destination
-        return .none
       }
     }
     .ifLet(\.$destination, action: \.destination)

--- a/Projects/App/Sources/RootCore.swift
+++ b/Projects/App/Sources/RootCore.swift
@@ -53,6 +53,7 @@ public struct RootCore {
     case getGroupsResponse(Result<GroupsData, Error>)
     case logError(RootCoreError)
     case setDestination(Destination.State?)
+    case logError(RootCoreError)
   }
   
   @Dependency(\.authAPIClient) private var authAPIClient
@@ -170,10 +171,6 @@ public struct RootCore {
         return .run { send in
           logger.error("RootCore Error: \(error)")
         }
-        
-      case let .setDestination(destination):
-        state.destination = destination
-        return .none
       }
     }
     .ifLet(\.$destination, action: \.destination)

--- a/Projects/Core/Common/Extensions/DateFormatter+extensions.swift
+++ b/Projects/Core/Common/Extensions/DateFormatter+extensions.swift
@@ -11,7 +11,7 @@ import Foundation
 public extension DateFormatter {
   static let iso8601: DateFormatter = {
     let formatter = DateFormatter()
-    formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
+    formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
     formatter.calendar = Calendar(identifier: .iso8601)
     formatter.timeZone = TimeZone(abbreviation: "KST")
     formatter.locale = Locale(identifier: "ko_KR")

--- a/Projects/Core/Models/BaseAPI/FailureResponse.swift
+++ b/Projects/Core/Models/BaseAPI/FailureResponse.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
 //
 
-import Foundation
-
 public struct FailureResponse: Decodable {
   public let isSuccess: Bool
   public let errorResponse: ErrorResponse

--- a/Projects/Core/Models/CreateGroup/Response/CreatedGroupInfo.swift
+++ b/Projects/Core/Models/CreateGroup/Response/CreatedGroupInfo.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
 //
 
-import Foundation
-
 public struct CreatedGroupInfo: Decodable, Equatable {
   public let id: Int
   public let groupName: String

--- a/Projects/Core/Models/CreateGroup/Response/FileUploadInfo.swift
+++ b/Projects/Core/Models/CreateGroup/Response/FileUploadInfo.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
 //
 
-import Foundation
-
 public struct FileUploadInfo: Decodable {
   public let uploadURL: String
   public let fileID: String

--- a/Projects/Core/Models/Event/Request/CreateEventsInfo.swift
+++ b/Projects/Core/Models/Event/Request/CreateEventsInfo.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
 //
 
-public struct CreateEventsInfo: Decodable, Equatable {
+public struct CreateEventsInfo: Encodable {
   public let groupID: Int
   public let description: String
   public let date: String

--- a/Projects/Core/Models/Event/Request/UploadEventImageInfo.swift
+++ b/Projects/Core/Models/Event/Request/UploadEventImageInfo.swift
@@ -1,0 +1,25 @@
+//
+//  UploadEventImageInfo.swift
+//  Models
+//
+//  Created by Hyun A Song on 8/16/24.
+//  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
+//
+
+public struct UploadEventImageInfo: Encodable {
+  public let eventID: Int
+  public let imageURL: [String]
+  
+  public init(
+    eventID: Int,
+    imageURL: [String]
+  ) {
+    self.eventID = eventID
+    self.imageURL = imageURL
+  }
+  
+  enum CodingKeys: String, CodingKey {
+    case eventID = "event_id"
+    case imageURL = "image_urls"
+  }
+}

--- a/Projects/Core/Models/Event/Request/UploadEventImageInfo.swift
+++ b/Projects/Core/Models/Event/Request/UploadEventImageInfo.swift
@@ -8,18 +8,18 @@
 
 public struct UploadEventImageInfo: Encodable {
   public let eventID: Int
-  public let imageURL: [String]
+  public let imageURLs: [String]
   
   public init(
     eventID: Int,
-    imageURL: [String]
+    imageURLs: [String]
   ) {
     self.eventID = eventID
-    self.imageURL = imageURL
+    self.imageURLs = imageURLs
   }
   
   enum CodingKeys: String, CodingKey {
     case eventID = "event_id"
-    case imageURL = "image_urls"
+    case imageURLs = "image_urls"
   }
 }

--- a/Projects/Core/Models/Event/Response/CreateEventsInfo.swift
+++ b/Projects/Core/Models/Event/Response/CreateEventsInfo.swift
@@ -1,0 +1,33 @@
+//
+//  CreateEventsInfo.swift
+//  Models
+//
+//  Created by Hyun A Song on 8/15/24.
+//  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
+//
+
+public struct CreateEventsInfo: Decodable, Equatable {
+  public let groupID: Int
+  public let description: String
+  public let date: String
+  public let pictures: [String]
+  
+  public init(
+    groupID: Int,
+    description: String,
+    date: String,
+    pictures: [String]
+  ) {
+    self.groupID = groupID
+    self.description = description
+    self.date = date
+    self.pictures = pictures
+  }
+  
+  enum CodingKeys: String, CodingKey {
+    case groupID = "group_id"
+    case description
+    case date
+    case pictures
+  }
+}

--- a/Projects/Core/Models/Event/Response/EventImageInfo.swift
+++ b/Projects/Core/Models/Event/Response/EventImageInfo.swift
@@ -1,0 +1,21 @@
+//
+//  EventImageInfo.swift
+//  Models
+//
+//  Created by Hyun A Song on 8/16/24.
+//  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
+//
+
+public struct EventImageInfo: Decodable {
+  public let eventID: Int
+  
+  public init(eventID: Int) {
+    self.eventID = eventID
+  }
+  
+  enum CodingKeys: String, CodingKey {
+    case eventID = "event_id"
+  }
+  
+  public static let mock: EventImageInfo = .init(eventID: 0)
+}

--- a/Projects/Core/Models/Event/Response/EventInfo.swift
+++ b/Projects/Core/Models/Event/Response/EventInfo.swift
@@ -1,0 +1,21 @@
+//
+//  EventInfo.swift
+//  Models
+//
+//  Created by Hyun A Song on 8/16/24.
+//  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
+//
+
+public struct EventInfo: Decodable {
+  public let eventID: Int
+  
+  public init(eventID: Int) {
+    self.eventID = eventID
+  }
+  
+  enum CodingKeys: String, CodingKey {
+    case eventID = "id"
+  }
+  
+  public static let mock: EventInfo = .init(eventID: 0)
+}

--- a/Projects/Core/Models/Event/Response/EventInfo.swift
+++ b/Projects/Core/Models/Event/Response/EventInfo.swift
@@ -7,15 +7,11 @@
 //
 
 public struct EventInfo: Decodable {
-  public let eventID: Int
+  public let id: Int
   
-  public init(eventID: Int) {
-    self.eventID = eventID
+  public init(id: Int) {
+    self.id = id
   }
   
-  enum CodingKeys: String, CodingKey {
-    case eventID = "id"
-  }
-  
-  public static let mock: EventInfo = .init(eventID: 0)
+  public static let mock: EventInfo = .init(id: 0)
 }

--- a/Projects/Core/Models/Event/Response/EventVisitInfo.swift
+++ b/Projects/Core/Models/Event/Response/EventVisitInfo.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
 //
 
-import Foundation
-
 public struct EventVisitInfo: Decodable {
   public var visited: Bool
   

--- a/Projects/Core/Models/Group/Response/CardBackImage.swift
+++ b/Projects/Core/Models/Group/Response/CardBackImage.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
 //
 
-import Foundation
-
 public struct CardBackImage: Decodable, Hashable {
   public let imageURL: String
   public let frame: Frame

--- a/Projects/Core/Models/Group/Response/GroupData.swift
+++ b/Projects/Core/Models/Group/Response/GroupData.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
 //
 
-import Foundation
-
 public struct GroupData: Decodable, Equatable {
   public let id: Int
   public let name: String

--- a/Projects/Core/Models/Group/Response/GroupDetailInfo.swift
+++ b/Projects/Core/Models/Group/Response/GroupDetailInfo.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
 //
 
-import Foundation
-
 public struct GroupDetailInfo: Decodable {
   public let id: Int
   public let name: String

--- a/Projects/Core/Models/Group/Response/GroupID.swift
+++ b/Projects/Core/Models/Group/Response/GroupID.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
 //
 
-import Foundation
-
 public struct GroupID: Decodable {
   public let groupID: Int
   

--- a/Projects/Core/Models/Group/Response/GroupsData.swift
+++ b/Projects/Core/Models/Group/Response/GroupsData.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
 //
 
-import Foundation
-
 public struct GroupsData: Decodable {
   public let groups: [GroupData]
 }

--- a/Projects/Core/Models/Group/Response/MemberList.swift
+++ b/Projects/Core/Models/Group/Response/MemberList.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
 //
 
-import Foundation
-
 public struct MemberList: Decodable, Hashable {
   public let members: [Member]
   public let invitationCode: String

--- a/Projects/Core/Models/PushNotification/Response/KookInfo.swift
+++ b/Projects/Core/Models/PushNotification/Response/KookInfo.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
 //
 
-import Foundation
-
 public struct KookInfo: Decodable {
   public let eventID: Int
   

--- a/Projects/Core/Models/PushNotification/Response/RegisteredFCMToken.swift
+++ b/Projects/Core/Models/PushNotification/Response/RegisteredFCMToken.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
 //
 
-import Foundation
-
 public struct RegisteredFCMToken: Decodable {
   public let registeredToken: String
   

--- a/Projects/Core/Models/Shared/UserInfo.swift
+++ b/Projects/Core/Models/Shared/UserInfo.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
 //
 
-import Foundation
-
 public struct UserInfo: Codable, Equatable {
   public var userID: Int
   public var nickname: String

--- a/Projects/Core/Models/Vote/Request/VoteReqDTO.swift
+++ b/Projects/Core/Models/Vote/Request/VoteReqDTO.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
 //
 
-import Foundation
-
 public struct VoteReqDTO: Encodable {
   public let eventID: Int
   public let likedOptionIDs: [Int]

--- a/Projects/Core/Models/Vote/Response/VoteCompleteInfo.swift
+++ b/Projects/Core/Models/Vote/Response/VoteCompleteInfo.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
 //
 
-import Foundation
-
 public struct VoteCompleteInfo: Decodable, Equatable {
   public var eventID: Int
   public var keyword: GroupData.Keyword

--- a/Projects/Core/Models/Vote/Response/VoteOptionInfo.swift
+++ b/Projects/Core/Models/Vote/Response/VoteOptionInfo.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
 //
 
-import Foundation
-
 public struct VoteOptionInfo: Decodable, Equatable {
   public let optionID: Int
   public let imageURL: String

--- a/Projects/Core/Services/Firebase/FirebaseClient.swift
+++ b/Projects/Core/Services/Firebase/FirebaseClient.swift
@@ -13,7 +13,7 @@ import Firebase
 public struct FirebaseClient: Sendable {
   public var configure: @Sendable () async -> Void
   public var runAutoInitialization: @Sendable () async -> Void
-  public var getDeviceToken: @Sendable (Data) async -> Void
+  public var setDeviceToken: @Sendable (Data) async -> Void
   public var checkRegistrationToken: @Sendable () async throws -> String
 }
 
@@ -26,7 +26,7 @@ extension FirebaseClient: DependencyKey {
       runAutoInitialization: {
         Messaging.messaging().isAutoInitEnabled = true
       },
-      getDeviceToken: { data in
+      setDeviceToken: { data in
         Messaging.messaging().apnsToken = data
       },
       checkRegistrationToken: {

--- a/Projects/Core/Services/PicAPIClients/EventAPI/EventAPI.swift
+++ b/Projects/Core/Services/PicAPIClients/EventAPI/EventAPI.swift
@@ -13,7 +13,7 @@ import Models
 public enum EventAPI {
   case putEventVisit(accessToken: String, eventID: Int)
   case createEvent(accessToken: String, groupID: Int, description: String, date: String, pictures: [String])
-  case uploadEventImages(accessToken: String, eventID: Int, imageURL: [String])
+  case uploadEventImages(accessToken: String, eventID: Int, imageURLs: [String])
 }
 
 extension EventAPI: RouteType {
@@ -59,10 +59,10 @@ extension EventAPI: RouteType {
         pictures: pictures
       )
       return body
-    case let .uploadEventImages(_, eventID, imageURL):
+    case let .uploadEventImages(_, eventID, imageURLs):
       let body = UploadEventImageInfo(
         eventID: eventID,
-        imageURL: imageURL
+        imageURLs: imageURLs
       )
       return body
     }
@@ -76,7 +76,7 @@ extension EventAPI: RouteType {
       ]
       return headers
     case let .createEvent(accessToken: accessToken, groupID: _, description: _, date: _, pictures: _),
-      let .uploadEventImages(accessToken: accessToken, eventID: _, imageURL: _):
+      let .uploadEventImages(accessToken: accessToken, eventID: _, imageURLs: _):
       return ["Authorization": "Bearer \(accessToken)"]
     }
   }

--- a/Projects/Core/Services/PicAPIClients/EventAPI/EventAPI.swift
+++ b/Projects/Core/Services/PicAPIClients/EventAPI/EventAPI.swift
@@ -8,9 +8,12 @@
 
 import Foundation
 import Get
+import Models
 
 public enum EventAPI {
   case putEventVisit(accessToken: String, eventID: Int)
+  case createEvent(accessToken: String, groupID: Int, description: String, date: String, pictures: [String])
+  case uploadEventImages(accessToken: String, eventID: Int, imageURL: [String])
 }
 
 extension EventAPI: RouteType {
@@ -18,6 +21,10 @@ extension EventAPI: RouteType {
     switch self {
     case .putEventVisit:
       return "/api/v1/events/visit"
+    case .createEvent:
+      return "/api/v1/events"
+    case .uploadEventImages:
+      return "/api/v1/events/images"
     }
   }
   
@@ -25,12 +32,14 @@ extension EventAPI: RouteType {
     switch self {
     case .putEventVisit:
       return .put
+    case .createEvent, .uploadEventImages:
+      return .post
     }
   }
   
   public var query: [(String, String?)]? {
     switch self {
-    case .putEventVisit:
+    case .putEventVisit, .createEvent, .uploadEventImages:
       return nil
     }
   }
@@ -42,6 +51,20 @@ extension EventAPI: RouteType {
         "event_id": eventID
       ]
       return body
+    case let .createEvent(_, groupID, description, date, pictures):
+      let body = CreateEventsInfo(
+        groupID: groupID,
+        description: description,
+        date: date,
+        pictures: pictures
+      )
+      return body
+    case let .uploadEventImages(_, eventID, imageURL):
+      let body = UploadEventImageInfo(
+        eventID: eventID,
+        imageURL: imageURL
+      )
+      return body
     }
   }
   
@@ -52,6 +75,9 @@ extension EventAPI: RouteType {
         "Authorization": "Bearer \(accessToken)"
       ]
       return headers
+    case let .createEvent(accessToken: accessToken, groupID: _, description: _, date: _, pictures: _),
+      let .uploadEventImages(accessToken: accessToken, eventID: _, imageURL: _):
+      return ["Authorization": "Bearer \(accessToken)"]
     }
   }
 }

--- a/Projects/Core/Services/PicAPIClients/EventAPI/EventAPI.swift
+++ b/Projects/Core/Services/PicAPIClients/EventAPI/EventAPI.swift
@@ -70,14 +70,13 @@ extension EventAPI: RouteType {
   
   public var headers: [String: String]? {
     switch self {
-    case let .putEventVisit(accessToken, eventID):
+    case let .putEventVisit(accessToken: accessToken, eventID: _),
+      let .createEvent(accessToken: accessToken, groupID: _, description: _, date: _, pictures: _),
+      let .uploadEventImages(accessToken: accessToken, eventID: _, imageURLs: _):
       let headers: [String: String]? = [
         "Authorization": "Bearer \(accessToken)"
       ]
       return headers
-    case let .createEvent(accessToken: accessToken, groupID: _, description: _, date: _, pictures: _),
-      let .uploadEventImages(accessToken: accessToken, eventID: _, imageURLs: _):
-      return ["Authorization": "Bearer \(accessToken)"]
     }
   }
 }

--- a/Projects/Core/Services/PicAPIClients/EventAPI/EventAPIClient.swift
+++ b/Projects/Core/Services/PicAPIClients/EventAPI/EventAPIClient.swift
@@ -87,13 +87,13 @@ extension EventAPIClient: DependencyKey {
   
   public static var previewValue: EventAPIClient {
     return EventAPIClient(
-      putEventVisit: { accessToken, eventID in
+      putEventVisit: { _, _ in
         return EventVisitInfo.mock
       },
-      createEvent: { accessToken, groupID, description, date, pictures in
+      createEvent: { _, _, _, _, _ in
         return EventInfo.mock
       },
-      uploadEventImages: { accessToken, eventID, imageURLs in
+      uploadEventImages: { _, _, _ in
         return EventImageInfo.mock
       }
     )

--- a/Projects/Core/Services/PicAPIClients/EventAPI/EventAPIClient.swift
+++ b/Projects/Core/Services/PicAPIClients/EventAPI/EventAPIClient.swift
@@ -13,7 +13,21 @@ import Models
 
 @DependencyClient
 public struct EventAPIClient: Sendable {
-  public var putEventVisit: @Sendable (_ accessToken: String, _ eventID: Int) async throws -> EventVisitInfo
+  public var putEventVisit: @Sendable (
+    _ accessToken: String,
+    _ eventID: Int
+  ) async throws -> EventVisitInfo
+  public var createEvent: @Sendable (
+    _ accessToken: String,
+    _ groupID: Int,
+    _ description: String,
+    _ date: String,
+    _ pictures: [String]
+  ) async throws -> EventInfo
+  public var uploadEventImages: @Sendable (
+    _ accessToken: String,
+    _ eventID: Int,
+    _ imageURL: [String]) async throws -> EventImageInfo
 }
 
 extension EventAPIClient: DependencyKey {
@@ -31,6 +45,42 @@ extension EventAPIClient: DependencyKey {
             underlying: error
           )
         }
+      },
+      createEvent: { accessToken, groupID, description, date, pictures in
+        let route = EventAPI.createEvent(
+          accessToken: accessToken,
+          groupID: groupID,
+          description: description,
+          date: date,
+          pictures: pictures
+        )
+        let request = Request<SuccessResponse<EventInfo>>(route: route)
+        do {
+          let response = try await NetworkManager.shared.send(request)
+          return response.value.data
+        } catch {
+          throw EventAPIClientError(
+            code: .failToCreateEvent,
+            underlying: error
+          )
+        }
+      },
+      uploadEventImages: { accessToken, eventID, imageURL in
+        let route = EventAPI.uploadEventImages(
+          accessToken: accessToken,
+          eventID: eventID,
+          imageURL: imageURL
+        )
+        let request = Request<SuccessResponse<EventImageInfo>>(route: route)
+        do {
+          let response = try await NetworkManager.shared.send(request)
+          return response.value.data
+        } catch {
+          throw EventAPIClientError(
+            code: .failTpUploadEventImage,
+            underlying: error
+          )
+        }
       }
     )
   }
@@ -39,6 +89,12 @@ extension EventAPIClient: DependencyKey {
     return EventAPIClient(
       putEventVisit: { accessToken, eventID in
         return EventVisitInfo.mock
+      },
+      createEvent: { accessToken, groupID, description, date, pictures in
+        return EventInfo.mock
+      },
+      uploadEventImages: { accessToken, eventID, imageURL in
+        return EventImageInfo.mock
       }
     )
   }
@@ -56,8 +112,10 @@ public struct EventAPIClientError: GabbangzipError {
   public var userInfo: [String: Any] = [:]
   public var code: APIResponseError
   public var underlying: Error?
-
+  
   public enum APIResponseError: Int {
     case failToPutEventVisit
+    case failToCreateEvent
+    case failTpUploadEventImage
   }
 }

--- a/Projects/Core/Services/PicAPIClients/EventAPI/EventAPIClient.swift
+++ b/Projects/Core/Services/PicAPIClients/EventAPI/EventAPIClient.swift
@@ -27,7 +27,7 @@ public struct EventAPIClient: Sendable {
   public var uploadEventImages: @Sendable (
     _ accessToken: String,
     _ eventID: Int,
-    _ imageURL: [String]) async throws -> EventImageInfo
+    _ imageURLs: [String]) async throws -> EventImageInfo
 }
 
 extension EventAPIClient: DependencyKey {
@@ -65,11 +65,11 @@ extension EventAPIClient: DependencyKey {
           )
         }
       },
-      uploadEventImages: { accessToken, eventID, imageURL in
+      uploadEventImages: { accessToken, eventID, imageURLs in
         let route = EventAPI.uploadEventImages(
           accessToken: accessToken,
           eventID: eventID,
-          imageURL: imageURL
+          imageURLs: imageURLs
         )
         let request = Request<SuccessResponse<EventImageInfo>>(route: route)
         do {
@@ -93,7 +93,7 @@ extension EventAPIClient: DependencyKey {
       createEvent: { accessToken, groupID, description, date, pictures in
         return EventInfo.mock
       },
-      uploadEventImages: { accessToken, eventID, imageURL in
+      uploadEventImages: { accessToken, eventID, imageURLs in
         return EventImageInfo.mock
       }
     )

--- a/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorCore.swift
@@ -38,8 +38,8 @@ public struct MainCoordinatorCore {
       case .router(.routeAction(id: _, action: .home(.moveToCreateGroup))):
         state.routes.presentCover(.createGroupCoordinator(.init(routes: [.root(.setGroupName(.init(isFromGetStarted: false)), embedInNavigationView: true)])))
         
-      case .router(.routeAction(id: _, action: .home(.moveToCreateEvent))):
-        state.routes.push(.createEvent(.init()))
+      case let .router(.routeAction(id: _, action: .home(.moveToCreateEvent(groupID)))):
+        state.routes.push(.createEvent(.init(groupID: groupID)))
         
       case .router(.routeAction(id: _, action: .home(.moveToJoinGroup))):
         state.routes.push(.joinGroup(.init(isFromGetStarted: false)))

--- a/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/MainCoordinator/MainCoordinatorCore.swift
@@ -38,8 +38,8 @@ public struct MainCoordinatorCore {
       case .router(.routeAction(id: _, action: .home(.moveToCreateGroup))):
         state.routes.presentCover(.createGroupCoordinator(.init(routes: [.root(.createGroupStart(.init()), embedInNavigationView: true)])))
         
-      case .router(.routeAction(id: _, action: .home(.moveToCreateEvent))):
-        state.routes.push(.createEvent(.init()))
+      case let .router(.routeAction(id: _, action: .home(.moveToCreateEvent(groupID)))):
+        state.routes.push(.createEvent(.init(groupID: groupID)))
         
       case .router(.routeAction(id: _, action: .home(.moveToJoinGroup))):
         state.routes.push(.joinGroup(.init()))

--- a/Projects/Features/Scene/CreateEventScene/CreateEventCore.swift
+++ b/Projects/Features/Scene/CreateEventScene/CreateEventCore.swift
@@ -201,15 +201,19 @@ public struct CreateEventCore {
         
       case .uploadFileToPresignedURLResponse(.success):
         return .run { [state] send in
-          await send(.createEvent(Result {
-            try await eventAPIClient.createEvent(
-              accessToken: state.userInfo.accessToken,
-              groupID: state.groupID,
-              description: state.text,
-              date: state.uploadEventDate,
-              pictures: state.imageURL
+          await send(
+            .createEvent(
+              Result {
+                try await eventAPIClient.createEvent(
+                  accessToken: state.userInfo.accessToken,
+                  groupID: state.groupID,
+                  description: state.text,
+                  date: state.uploadEventDate,
+                  pictures: state.imageURL
+                )
+              }
             )
-          }))
+          )
         }
         
       case .uploadFileToPresignedURLResponse(.failure):

--- a/Projects/Features/Scene/CreateEventScene/CreateEventCore.swift
+++ b/Projects/Features/Scene/CreateEventScene/CreateEventCore.swift
@@ -28,6 +28,7 @@ public struct CreateEventCore {
     public var isPhotoSelected: Bool
     public var completeButtonType: ButtonType
     public var selectedPhotosInfo: [PhotoInfo]
+    public var imageURL: [String]
     public var recentEventDate: String {
       return DateFormatter.createEvent.string(from: Date())
     }
@@ -44,7 +45,8 @@ public struct CreateEventCore {
       isEventNamed: Bool = false,
       isPhotoSelected: Bool = false,
       completeButtonType: ButtonType = .inactive,
-      selectedPhotosInfo: [PhotoInfo] = []
+      selectedPhotosInfo: [PhotoInfo] = [],
+      imageURL: [String] = []
     ) {
       self._userInfo = Shared(wrappedValue: userInfo(), .inMemory("userInfo"))
       self.groupID = groupID
@@ -55,6 +57,7 @@ public struct CreateEventCore {
       self.isPhotoSelected = isPhotoSelected
       self.completeButtonType = completeButtonType
       self.selectedPhotosInfo = selectedPhotosInfo
+      self.imageURL = imageURL
     }
   }
   
@@ -77,9 +80,7 @@ public struct CreateEventCore {
     case setToastPresented(Bool)
     case getUploadURLResponse(Result<FileUploadInfo, Error>, PhotoInfo)
     case uploadFileToPresignedURLResponse(Result<Void, Error>)
-    case createEventResponse
-    case checkEvent(Result<EventInfo, Error>)
-    case uploadEventImage(Result<EventImageInfo, Error>)
+    case createEvent(Result<EventInfo, Error>)
     case logError(Error)
     
     // Route Action
@@ -178,14 +179,19 @@ public struct CreateEventCore {
         return .none
         
       case let .getUploadURLResponse(.success(fileUploadInfo), photoInfo):
+        state.imageURL.append(fileUploadInfo.fileID)
         return .run { send in
-          await send(.uploadFileToPresignedURLResponse(Result {
-            try await fileUploadAPIClient.uploadFile(
-              uploadURL: fileUploadInfo.uploadURL,
-              data: photoInfo.data,
-              fileExtension: photoInfo.fileExtension
+          await send(
+            .uploadFileToPresignedURLResponse(
+              Result {
+                try await fileUploadAPIClient.uploadFile(
+                  uploadURL: fileUploadInfo.uploadURL,
+                  data: photoInfo.data,
+                  fileExtension: photoInfo.fileExtension
+                )
+              }
             )
-          }))
+          )
         }
         
       case .getUploadURLResponse(.failure, _):
@@ -194,8 +200,16 @@ public struct CreateEventCore {
         }
         
       case .uploadFileToPresignedURLResponse(.success):
-        return .run { send in
-          await send(.createEventResponse)
+        return .run { [state] send in
+          await send(.createEvent(Result {
+            try await eventAPIClient.createEvent(
+              accessToken: state.userInfo.accessToken,
+              groupID: state.groupID,
+              description: state.text,
+              date: state.uploadEventDate,
+              pictures: state.imageURL
+            )
+          }))
         }
         
       case .uploadFileToPresignedURLResponse(.failure):
@@ -203,45 +217,14 @@ public struct CreateEventCore {
           await send(.logError(CreateEventCoreError(code: .failTeUploadFileToPresignedURLResponse)))
         }
         
-      case .createEventResponse:
-        return .run { [state] send in
-          let pictures = state.selectedPhotosInfo.map{ $0.fileExtension }
-          await send(.checkEvent(Result {
-            try await eventAPIClient.createEvent(
-              accessToken: state.userInfo.accessToken,
-              groupID: state.groupID,
-              description: state.text,
-              date: state.uploadEventDate,
-              pictures: pictures
-            )
-          }))
-        }
-        
-      case let .checkEvent(.success(eventInfo)):
-        return .run { [state] send in
-          let pictures = state.selectedPhotosInfo.map{ $0.url.description }
-          await send(.uploadEventImage(Result {
-            try await eventAPIClient.uploadEventImages(
-              accessToken: state.userInfo.accessToken,
-              eventID: eventInfo.eventID,
-              imageURL: pictures
-            )
-          }))
-        }
-        
-      case .checkEvent(.failure):
-        return .run { send in
-          await send(.logError(CreateEventCoreError(code: .failToCheckEvent)))
-        }
-        
-      case .uploadEventImage(.success):
+      case let .createEvent(.success(eventInfo)):
         return .run { send in
           await send(.moveToHomeWithEvent)
         }
         
-      case .uploadEventImage(.failure):
+      case .createEvent(.failure):
         return .run { send in
-          await send(.logError(CreateEventCoreError(code: .failToUploadEventImage)))
+          await send(.logError(CreateEventCoreError(code: .failToCheckEvent)))
         }
         
       case let .logError(error):
@@ -270,7 +253,6 @@ public struct CreateEventCoreError: GabbangzipError {
     case failToUploadURL
     case failToGetUploadURLResponse
     case failTeUploadFileToPresignedURLResponse
-    case failToCreateEventResponse
     case failToUploadEventImage
     case failToCheckEvent
   }

--- a/Projects/Features/Scene/CreateEventScene/CreateEventCore.swift
+++ b/Projects/Features/Scene/CreateEventScene/CreateEventCore.swift
@@ -21,6 +21,7 @@ public struct CreateEventCore {
   public struct State: Equatable {
     public var text: String
     public var isExiting: Bool
+    public var isErrorPresented: Bool
     public var isEventNamed: Bool
     public var isPhotoSelected: Bool
     public var completeButtonType: ButtonType
@@ -32,6 +33,7 @@ public struct CreateEventCore {
     public init(
       text: String = "",
       isExiting: Bool = false,
+      isErrorPresented: Bool = false,
       isEventNamed: Bool = false,
       isPhotoSelected: Bool = false,
       completeButtonType: ButtonType = .inactive,
@@ -39,6 +41,7 @@ public struct CreateEventCore {
     ) {
       self.text = text
       self.isExiting = isExiting
+      self.isErrorPresented = isErrorPresented
       self.isEventNamed = isEventNamed
       self.isPhotoSelected = isPhotoSelected
       self.completeButtonType = completeButtonType
@@ -62,6 +65,7 @@ public struct CreateEventCore {
     case changeIsEventNamedStatus(Bool)
     case changeIsPhotoSelected
     case checkCompleteButtonType
+    case setToastPresented(Bool)
     
     // Route Action
     case moveToHome
@@ -130,6 +134,16 @@ public struct CreateEventCore {
         state.completeButtonType = state.isEventNamed && state.isPhotoSelected ? .active : .inactive
         return .none
         
+      case let .setToastPresented(isPresented):
+        state.isErrorPresented = isPresented
+        return .none
+        
+        
+      case let .logError(error):
+        return .run { send in
+          logger.error("CreateEvent Error: \(error)")
+        }
+        
       case .moveToHome:
         return .none
         
@@ -137,5 +151,17 @@ public struct CreateEventCore {
         return .none
       }
     }
+  }
+}
+
+// MARK: - CreateEventCoreError
+public struct CreateEventCoreError: GabbangzipError {
+  public var userInfo: [String: Any] = [:]
+  public var code: Code
+  public var underlying: Error?
+  
+  public enum Code: Int {
+    case failToGetUploadURLResponse
+    case failToUploadEventImage
   }
 }

--- a/Projects/Features/Scene/CreateEventScene/CreateEventCore.swift
+++ b/Projects/Features/Scene/CreateEventScene/CreateEventCore.swift
@@ -19,6 +19,8 @@ public struct CreateEventCore {
   
   @ObservableState
   public struct State: Equatable {
+    @Shared var userInfo: UserInfo
+    public var groupID: Int
     public var text: String
     public var isExiting: Bool
     public var isErrorPresented: Bool
@@ -29,8 +31,13 @@ public struct CreateEventCore {
     public var recentEventDate: String {
       return DateFormatter.createEvent.string(from: Date())
     }
+    public var uploadEventDate: String {
+      return DateFormatter.iso8601.string(from: Date())
+    }
     
     public init(
+      userInfo: @autoclosure () -> UserInfo = .defaultValue,
+      groupID: Int = -1,
       text: String = "",
       isExiting: Bool = false,
       isErrorPresented: Bool = false,
@@ -39,6 +46,8 @@ public struct CreateEventCore {
       completeButtonType: ButtonType = .inactive,
       selectedPhotosInfo: [PhotoInfo] = []
     ) {
+      self._userInfo = Shared(wrappedValue: userInfo(), .inMemory("userInfo"))
+      self.groupID = groupID
       self.text = text
       self.isExiting = isExiting
       self.isErrorPresented = isErrorPresented

--- a/Projects/Features/Scene/CreateEventScene/CreateEventCore.swift
+++ b/Projects/Features/Scene/CreateEventScene/CreateEventCore.swift
@@ -75,6 +75,12 @@ public struct CreateEventCore {
     case changeIsPhotoSelected
     case checkCompleteButtonType
     case setToastPresented(Bool)
+    case getUploadURLResponse(Result<FileUploadInfo, Error>, PhotoInfo)
+    case uploadFileToPresignedURLResponse(Result<Void, Error>)
+    case createEventResponse
+    case checkEvent(Result<EventInfo, Error>)
+    case uploadEventImage(Result<EventImageInfo, Error>)
+    case logError(Error)
     
     // Route Action
     case moveToHome
@@ -82,6 +88,8 @@ public struct CreateEventCore {
   }
   
   @Dependency(\.bundleClient) var bundleClient
+  @Dependency(\.eventAPIClient) var eventAPIClient
+  @Dependency(\.fileUploadAPIClient) var fileUploadAPIClient
   @Dependency(\.uiPasteBoardClient) var uiPasteBoardClient
   
   public var body: some Reducer<State, Action> {
@@ -117,8 +125,30 @@ public struct CreateEventCore {
         return .none
         
       case .completeButtonTapped:
-        return .run { send in
-          await send(.moveToHomeWithEvent)
+        return .run { [state] send in
+          guard state.isPhotoSelected else {
+            await send(.setToastPresented(true))
+            return
+          }
+          
+          await withTaskGroup(of: Void.self) { taskGroup in
+            for photo in state.selectedPhotosInfo {
+              taskGroup.addTask {
+                await send(.getUploadURLResponse(
+                  Result {
+                    let result = try await fileUploadAPIClient.getUploadURL(
+                      state.userInfo.accessToken,
+                      photo.fileExtension
+                    )
+                    return result
+                  },
+                  photo)
+                )
+              }
+            }
+          }
+        } catch: { error, send in
+          await send(.logError(CreateEventCoreError(code: .failToUploadURL, underlying: error)))
         }
         
       case let .deleteSelectedPhoto(index):
@@ -147,8 +177,75 @@ public struct CreateEventCore {
         state.isErrorPresented = isPresented
         return .none
         
+      case let .getUploadURLResponse(.success(fileUploadInfo), photoInfo):
+        return .run { send in
+          await send(.uploadFileToPresignedURLResponse(Result {
+            try await fileUploadAPIClient.uploadFile(
+              uploadURL: fileUploadInfo.uploadURL,
+              data: photoInfo.data,
+              fileExtension: photoInfo.fileExtension
+            )
+          }))
+        }
+        
+      case .getUploadURLResponse(.failure, _):
+        return .run { send in
+          await send(.logError(CreateEventCoreError(code: .failToGetUploadURLResponse)))
+        }
+        
+      case .uploadFileToPresignedURLResponse(.success):
+        return .run { send in
+          await send(.createEventResponse)
+        }
+        
+      case .uploadFileToPresignedURLResponse(.failure):
+        return .run { send in
+          await send(.logError(CreateEventCoreError(code: .failTeUploadFileToPresignedURLResponse)))
+        }
+        
+      case .createEventResponse:
+        return .run { [state] send in
+          let pictures = state.selectedPhotosInfo.map{ $0.fileExtension }
+          await send(.checkEvent(Result {
+            try await eventAPIClient.createEvent(
+              accessToken: state.userInfo.accessToken,
+              groupID: state.groupID,
+              description: state.text,
+              date: state.uploadEventDate,
+              pictures: pictures
+            )
+          }))
+        }
+        
+      case let .checkEvent(.success(eventInfo)):
+        return .run { [state] send in
+          let pictures = state.selectedPhotosInfo.map{ $0.url.description }
+          await send(.uploadEventImage(Result {
+            try await eventAPIClient.uploadEventImages(
+              accessToken: state.userInfo.accessToken,
+              eventID: eventInfo.eventID,
+              imageURL: pictures
+            )
+          }))
+        }
+        
+      case .checkEvent(.failure):
+        return .run { send in
+          await send(.logError(CreateEventCoreError(code: .failToCheckEvent)))
+        }
+        
+      case .uploadEventImage(.success):
+        return .run { send in
+          await send(.moveToHomeWithEvent)
+        }
+        
+      case .uploadEventImage(.failure):
+        return .run { send in
+          await send(.logError(CreateEventCoreError(code: .failToUploadEventImage)))
+        }
         
       case let .logError(error):
+        state.isErrorPresented = true
         return .run { send in
           logger.error("CreateEvent Error: \(error)")
         }
@@ -170,7 +267,11 @@ public struct CreateEventCoreError: GabbangzipError {
   public var underlying: Error?
   
   public enum Code: Int {
+    case failToUploadURL
     case failToGetUploadURLResponse
+    case failTeUploadFileToPresignedURLResponse
+    case failToCreateEventResponse
     case failToUploadEventImage
+    case failToCheckEvent
   }
 }

--- a/Projects/Features/Scene/CreateEventScene/CreateEventView.swift
+++ b/Projects/Features/Scene/CreateEventScene/CreateEventView.swift
@@ -42,9 +42,12 @@ public struct CreateEventView: View {
           .padding(.top, 16)
         
         EventView(text: CreateEventViewNameSpace.eventPicture)
-        
-        EventPicturePickerView(store: store)
-        
+      }
+      .padding(.horizontal, 16)
+      
+      EventPicturePickerView(store: store)
+      
+      VStack(spacing: 0) {
         Spacer()
         
         Text(CreateEventViewNameSpace.notice)
@@ -59,8 +62,8 @@ public struct CreateEventView: View {
         )
       }
       .padding(.horizontal, 16)
-      .navigationBarHidden(true)
     }
+    .navigationBarHidden(true)
     .toast(isPresented: $store.isErrorPresented, type: .onlyText("다시 시도해주세요."))
     .popup(
       isPresented: $store.isExiting,
@@ -180,6 +183,8 @@ fileprivate struct EventPicturePickerView: View {
               .padding(.leading, 8)
             }
           }
+          
+          Spacer()
         }
       }
     } else {

--- a/Projects/Features/Scene/CreateEventScene/CreateEventView.swift
+++ b/Projects/Features/Scene/CreateEventScene/CreateEventView.swift
@@ -61,6 +61,7 @@ public struct CreateEventView: View {
       .padding(.horizontal, 16)
       .navigationBarHidden(true)
     }
+    .toast(isPresented: $store.isErrorPresented, type: .onlyText("다시 시도해주세요."))
     .popup(
       isPresented: $store.isExiting,
       title: CreateEventViewNameSpace.popupTitle,

--- a/Projects/Features/Scene/CreateGroupScene/CreateGroupCompletion/CreateGroupCompletionCore.swift
+++ b/Projects/Features/Scene/CreateGroupScene/CreateGroupCompletion/CreateGroupCompletionCore.swift
@@ -59,7 +59,7 @@ public struct CreateGroupCompletionCore {
       switch action {
       case .onAppear:
         return .run { [state] send in
-          if let s3BucketDomain = try? bundleClient.getValue(key: "S3BucketDomain") as? String {
+          if let s3BucketDomain = try? bundleClient.getValue("S3BucketDomain") as? String {
             let imageURLString = s3BucketDomain + state.createdGroupInfo.groupImageURL
             await send(.setImageURLString(imageURLString))
           }

--- a/Projects/Features/Scene/CreateGroupScene/CreateGroupCompletion/CreateGroupCompletionCore.swift
+++ b/Projects/Features/Scene/CreateGroupScene/CreateGroupCompletion/CreateGroupCompletionCore.swift
@@ -55,7 +55,7 @@ public struct CreateGroupCompletionCore {
       switch action {
       case .onAppear:
         return .run { [state] send in
-          if let s3BucketDomain = try? bundleClient.getValue(key: "S3BucketDomain") as? String {
+          if let s3BucketDomain = try? bundleClient.getValue("S3BucketDomain") as? String {
             let imageURLString = s3BucketDomain + state.createdGroupInfo.groupImageURL
             await send(.setImageURLString(imageURLString))
           }

--- a/Projects/Features/Scene/CreateGroupScene/SelectGroupPhoto/SelectGroupPhotoCore.swift
+++ b/Projects/Features/Scene/CreateGroupScene/SelectGroupPhoto/SelectGroupPhotoCore.swift
@@ -72,8 +72,8 @@ public struct SelectGroupPhotoCore {
               .getUploadURLResponse(
                 Result {
                   try await self.fileUploadAPIClient.getUploadURL(
-                    accessToken: state.userInfo.accessToken,
-                    fileExtension: photoInfo.fileExtension)
+                    state.userInfo.accessToken,
+                    photoInfo.fileExtension)
                 }, photoInfo
               )
             )
@@ -96,9 +96,9 @@ public struct SelectGroupPhotoCore {
             .uploadFileToPresignedURLResponse(
               Result {
                 try await self.fileUploadAPIClient.uploadFile(
-                  uploadURL: fileUploadInfo.uploadURL,
-                  data: photoInfo.data,
-                  fileExtension: photoInfo.fileExtension)
+                  fileUploadInfo.uploadURL,
+                  photoInfo.data,
+                  photoInfo.fileExtension)
               },
               fileUploadInfo
             )
@@ -114,10 +114,10 @@ public struct SelectGroupPhotoCore {
         return .run { [state] send in
           await send(.createGroupResponse(Result {
             try await self.createGroupAPIClient.createGroup(
-              accessToken: state.userInfo.accessToken,
-              groupName: state.groupName,
-              keyword: state.keyword.rawValue,
-              groupImageURL: fileUploadInfo.fileID
+              state.userInfo.accessToken,
+              state.groupName,
+              state.keyword.rawValue,
+              fileUploadInfo.fileID
             )
           }))
         }

--- a/Projects/Features/Scene/CreateGroupScene/SelectGroupPhoto/SelectGroupPhotoCore.swift
+++ b/Projects/Features/Scene/CreateGroupScene/SelectGroupPhoto/SelectGroupPhotoCore.swift
@@ -76,7 +76,8 @@ public struct SelectGroupPhotoCore {
                 Result {
                   try await self.fileUploadAPIClient.getUploadURL(
                     state.userInfo.accessToken,
-                    photoInfo.fileExtension)
+                    photoInfo.fileExtension
+                  )
                 }, photoInfo
               )
             )

--- a/Projects/Features/Scene/CreateGroupScene/SelectGroupPhoto/SelectGroupPhotoCore.swift
+++ b/Projects/Features/Scene/CreateGroupScene/SelectGroupPhoto/SelectGroupPhotoCore.swift
@@ -75,8 +75,8 @@ public struct SelectGroupPhotoCore {
               .getUploadURLResponse(
                 Result {
                   try await self.fileUploadAPIClient.getUploadURL(
-                    accessToken: state.userInfo.accessToken,
-                    fileExtension: photoInfo.fileExtension)
+                    state.userInfo.accessToken,
+                    photoInfo.fileExtension)
                 }, photoInfo
               )
             )
@@ -99,9 +99,9 @@ public struct SelectGroupPhotoCore {
             .uploadFileToPresignedURLResponse(
               Result {
                 try await self.fileUploadAPIClient.uploadFile(
-                  uploadURL: fileUploadInfo.uploadURL,
-                  data: photoInfo.data,
-                  fileExtension: photoInfo.fileExtension)
+                  fileUploadInfo.uploadURL,
+                  photoInfo.data,
+                  photoInfo.fileExtension)
               },
               fileUploadInfo
             )
@@ -117,10 +117,10 @@ public struct SelectGroupPhotoCore {
         return .run { [state] send in
           await send(.createGroupResponse(Result {
             try await self.createGroupAPIClient.createGroup(
-              accessToken: state.userInfo.accessToken,
-              groupName: state.groupName,
-              keyword: state.keyword.rawValue,
-              groupImageURL: fileUploadInfo.fileID
+              state.userInfo.accessToken,
+              state.groupName,
+              state.keyword.rawValue,
+              fileUploadInfo.fileID
             )
           }))
         }

--- a/Projects/Features/Scene/CreateGroupScene/SelectGroupPhoto/SelectGroupPhotoCore.swift
+++ b/Projects/Features/Scene/CreateGroupScene/SelectGroupPhoto/SelectGroupPhotoCore.swift
@@ -73,7 +73,8 @@ public struct SelectGroupPhotoCore {
                 Result {
                   try await self.fileUploadAPIClient.getUploadURL(
                     state.userInfo.accessToken,
-                    photoInfo.fileExtension)
+                    photoInfo.fileExtension
+                  )
                 }, photoInfo
               )
             )

--- a/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailCore.swift
+++ b/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailCore.swift
@@ -56,7 +56,7 @@ public struct GroupDetailCore {
       showSheet: Bool = true,
       selectedPhotosInfo: [PhotoInfo] = [],
       isToastPresented: Bool = false,
-      toastType: ToastType = .onlyText(""),
+      toastType: ToastType = .onlyText("다시 시도해주세요."),
       s3BucketDomain: String = "",
       showActivityView: Bool = false,
       capturedImage: UIImage? = nil,
@@ -195,9 +195,12 @@ public struct GroupDetailCore {
         }
         
       case .getGroupDetailResponse(.failure):
+        state.isToastPresented = true
+        return .none
         return .none
         
-      case .putEventVisit:
+      case .putEventVisit(.failure):
+        state.isToastPresented = true
         return .none
         
       case .postKook:

--- a/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailCore.swift
+++ b/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailCore.swift
@@ -140,8 +140,8 @@ public struct GroupDetailCore {
           return .run { [state] send in
             await send(.postKook(Result {
               try await self.pushAPIClienet.kook(
-                accessToken: state.userInfo.accessToken,
-                eventID: state.groupDetail?.recentEventDetail.id ?? 0
+                state.userInfo.accessToken,
+                state.groupDetail?.recentEventDetail.id ?? 0
               )
             }))
           }
@@ -165,7 +165,11 @@ public struct GroupDetailCore {
         }
         
       case let .historyViewTapped(history):
-        return .send(GroupDetailCore.Action.moveToHistoryDetail(history, state.groupDetail?.keyword, state.s3BucketDomain))
+        return .send(GroupDetailCore.Action.moveToHistoryDetail(
+          history,
+          state.groupDetail?.keyword,
+          state.s3BucketDomain
+        ))
         
       case .shareButtonTapped:
         state.showActivityView = true
@@ -184,8 +188,8 @@ public struct GroupDetailCore {
             operation: { [state] send in
               await send(.putEventVisit(Result {
                 try await self.eventAPIClient.putEventVisit(
-                  accessToken: state.userInfo.accessToken,
-                  eventID: state.groupDetail?.recentEventDetail.id ?? -1
+                  state.userInfo.accessToken,
+                  state.groupDetail?.recentEventDetail.id ?? -1
                 )
               }))
             }

--- a/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailCore.swift
+++ b/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailCore.swift
@@ -197,6 +197,8 @@ public struct GroupDetailCore {
       case .getGroupDetailResponse(.failure):
         state.isToastPresented = true
         return .none
+        
+      case .putEventVisit(.success):
         return .none
         
       case .putEventVisit(.failure):

--- a/Projects/Features/Scene/LoginScene/Login/LoginCore.swift
+++ b/Projects/Features/Scene/LoginScene/Login/LoginCore.swift
@@ -19,27 +19,30 @@ public struct LoginCore {
   
   @ObservableState
   public struct State: Equatable {
+    @Shared var userInfo: UserInfo
     public var isPresented: Bool
     public var kakaoUser: KaKaoUserInfo
     public var kakaoIdToken: KakaoToken
-    @Shared var userInfo: UserInfo
+    public var FCMToken: String
     
     public init(
+      userInfo: @autoclosure () -> UserInfo = .defaultValue,
       isPresented: Bool = false,
       kakaoUser: KaKaoUserInfo = KaKaoUserInfo(),
       kakaoIdToken: KakaoToken = KakaoToken(),
-      userInfo: @autoclosure () -> UserInfo = .defaultValue
+      FCMToken: String = ""
     ) {
+      self._userInfo = Shared(wrappedValue: userInfo(), .inMemory("userInfo"))
       self.isPresented = isPresented
       self.kakaoUser = kakaoUser
       self.kakaoIdToken = kakaoIdToken
-      self._userInfo = Shared(wrappedValue: userInfo(), .inMemory("userInfo"))
+      self.FCMToken = FCMToken
     }
   }
   
   public enum Action: BindableAction {
     case binding(BindingAction<State>)
-
+    
     // View Action
     case loginButtonTapped
     
@@ -48,6 +51,9 @@ public struct LoginCore {
     case loginWithKakaoAccountResponse(Result<String?, Error>)
     case checkUserInformationResponse(Result<User, Error>)
     case loginResponse(Result<PICUserInfo, Error>)
+    case getFCMToken(String)
+    case postFCMToken
+    case responseFCMToken(Result<RegisteredFCMToken, Error>)
     case saveUserInfoToKeychain(Result<Void, Error>)
     case showError(Bool)
     case logError(LoginCoreError)
@@ -56,10 +62,12 @@ public struct LoginCore {
     case moveToHome
   }
   
-  @Dependency(\.kakaoLoginClient) private var kakaoLoginClient
   @Dependency(\.authAPIClient) private var authAPIClient
+  @Dependency(\.firebaseClient) private var firebaseClient
+  @Dependency(\.kakaoLoginClient) private var kakaoLoginClient
   @Dependency(\.keyChainClient) private var keyChainClient
   @Dependency(\.userDefaultsClient) private var userDefaultsClient
+  @Dependency(\.pushNotificationAPIClient) private var pushNotificationAPIClient
   
   public var body: some Reducer<State, Action> {
     BindingReducer()
@@ -107,10 +115,14 @@ public struct LoginCore {
           if let idToken = state.kakaoIdToken.idToken,
              let nickname = state.kakaoUser.nickname,
              let profileImageUrl = state.kakaoUser.profileImageUrl?.absoluteString {
+            let token = try await firebaseClient.checkRegistrationToken()
+            await send(.getFCMToken(token))
             await send(.loginResponse(Result { try await authAPIClient.login(idToken, nickname, profileImageUrl) }))
           } else {
             await send(.loginResponse(.failure(LoginCoreError(code: .failToCheckUserInformation))))
           }
+        } catch: { error,send in
+          await send(.loginResponse(.failure(LoginCoreError(code: .failToRegistrationToken, underlying: error))))
         }
         
       case .checkUserInformationResponse(.failure):
@@ -135,6 +147,30 @@ public struct LoginCore {
         return .run { send in
           await send(.logError(LoginCoreError(code: .failToLogin)))
           await send(.showError(true))
+        }
+        
+      case let .getFCMToken(token):
+        state.FCMToken = token
+        return .run { send in
+          await send(.postFCMToken)
+        }
+        
+      case .postFCMToken:
+        return .run { [state] send in
+          await send(.responseFCMToken(Result {
+            try await self.pushNotificationAPIClient.registerFCMToken(
+              state.userInfo.accessToken,
+              state.FCMToken
+            )
+          }))
+        }
+        
+      case .responseFCMToken(.success):
+        return .none
+        
+      case .responseFCMToken(.failure):
+        return .run { send in
+          await send(.logError(LoginCoreError(code: .failToPostFCMToken)))
         }
         
       case .saveUserInfoToKeychain(.success):
@@ -168,8 +204,10 @@ public struct LoginCoreError: GabbangzipError {
   public var underlying: Error?
   
   public enum Code: Int {
+    case failToRegistrationToken
     case failToCheckUserInformation
     case failToLogin
+    case failToPostFCMToken
     case failToSaveUserInfoToKeychain
   }
 }

--- a/Projects/Features/Scene/LoginScene/Login/LoginCore.swift
+++ b/Projects/Features/Scene/LoginScene/Login/LoginCore.swift
@@ -23,20 +23,20 @@ public struct LoginCore {
     public var isPresented: Bool
     public var kakaoUser: KaKaoUserInfo
     public var kakaoIdToken: KakaoToken
-    public var FCMToken: String
+    public var fcmToken: String
     
     public init(
       userInfo: @autoclosure () -> UserInfo = .defaultValue,
       isPresented: Bool = false,
       kakaoUser: KaKaoUserInfo = KaKaoUserInfo(),
       kakaoIdToken: KakaoToken = KakaoToken(),
-      FCMToken: String = ""
+      fcmToken: String = ""
     ) {
       self._userInfo = Shared(wrappedValue: userInfo(), .inMemory("userInfo"))
       self.isPresented = isPresented
       self.kakaoUser = kakaoUser
       self.kakaoIdToken = kakaoIdToken
-      self.FCMToken = FCMToken
+      self.fcmToken = fcmToken
     }
   }
   
@@ -150,7 +150,7 @@ public struct LoginCore {
         }
         
       case let .getFCMToken(token):
-        state.FCMToken = token
+        state.fcmToken = token
         return .run { send in
           await send(.postFCMToken)
         }
@@ -160,7 +160,7 @@ public struct LoginCore {
           await send(.responseFCMToken(Result {
             try await self.pushNotificationAPIClient.registerFCMToken(
               state.userInfo.accessToken,
-              state.FCMToken
+              state.fcmToken
             )
           }))
         }

--- a/Projects/Features/Scene/LoginScene/Login/LoginCore.swift
+++ b/Projects/Features/Scene/LoginScene/Login/LoginCore.swift
@@ -23,20 +23,20 @@ public struct LoginCore {
     public var isPresented: Bool
     public var kakaoUser: KaKaoUserInfo
     public var kakaoIdToken: KakaoToken
-    public var FCMToken: String
+    public var fcmToken: String
     
     public init(
       userInfo: @autoclosure () -> UserInfo = .defaultValue,
       isPresented: Bool = false,
       kakaoUser: KaKaoUserInfo = KaKaoUserInfo(),
       kakaoIdToken: KakaoToken = KakaoToken(),
-      FCMToken: String = ""
+      fcmToken: String = ""
     ) {
       self._userInfo = Shared(wrappedValue: userInfo(), .inMemory("userInfo"))
       self.isPresented = isPresented
       self.kakaoUser = kakaoUser
       self.kakaoIdToken = kakaoIdToken
-      self.FCMToken = FCMToken
+      self.fcmToken = fcmToken
     }
   }
   
@@ -155,7 +155,7 @@ public struct LoginCore {
         }
         
       case let .getFCMToken(token):
-        state.FCMToken = token
+        state.fcmToken = token
         return .run { send in
           await send(.postFCMToken)
         }
@@ -165,7 +165,7 @@ public struct LoginCore {
           await send(.responseFCMToken(Result {
             try await self.pushNotificationAPIClient.registerFCMToken(
               state.userInfo.accessToken,
-              state.FCMToken
+              state.fcmToken
             )
           }))
         }

--- a/Projects/Features/Scene/LoginScene/Login/LoginCore.swift
+++ b/Projects/Features/Scene/LoginScene/Login/LoginCore.swift
@@ -19,27 +19,30 @@ public struct LoginCore {
   
   @ObservableState
   public struct State: Equatable {
+    @Shared var userInfo: UserInfo
     public var isPresented: Bool
     public var kakaoUser: KaKaoUserInfo
     public var kakaoIdToken: KakaoToken
-    @Shared var userInfo: UserInfo
+    public var FCMToken: String
     
     public init(
+      userInfo: @autoclosure () -> UserInfo = .defaultValue,
       isPresented: Bool = false,
       kakaoUser: KaKaoUserInfo = KaKaoUserInfo(),
       kakaoIdToken: KakaoToken = KakaoToken(),
-      userInfo: @autoclosure () -> UserInfo = .defaultValue
+      FCMToken: String = ""
     ) {
+      self._userInfo = Shared(wrappedValue: userInfo(), .inMemory("userInfo"))
       self.isPresented = isPresented
       self.kakaoUser = kakaoUser
       self.kakaoIdToken = kakaoIdToken
-      self._userInfo = Shared(wrappedValue: userInfo(), .inMemory("userInfo"))
+      self.FCMToken = FCMToken
     }
   }
   
   public enum Action: BindableAction {
     case binding(BindingAction<State>)
-
+    
     // View Action
     case loginButtonTapped
     
@@ -48,6 +51,9 @@ public struct LoginCore {
     case loginWithKakaoAccountResponse(Result<String?, Error>)
     case checkUserInformationResponse(Result<User, Error>)
     case loginResponse(Result<PICUserInfo, Error>)
+    case getFCMToken(String)
+    case postFCMToken
+    case responseFCMToken(Result<RegisteredFCMToken, Error>)
     case saveUserInfoToKeychain(Result<Void, Error>)
     case getGroupsResponse(Result<GroupsData, Error>)
     case showError(Bool)
@@ -58,10 +64,12 @@ public struct LoginCore {
     case moveToGetStarted
   }
   
-  @Dependency(\.kakaoLoginClient) private var kakaoLoginClient
   @Dependency(\.authAPIClient) private var authAPIClient
+  @Dependency(\.firebaseClient) private var firebaseClient
+  @Dependency(\.kakaoLoginClient) private var kakaoLoginClient
   @Dependency(\.keyChainClient) private var keyChainClient
   @Dependency(\.userDefaultsClient) private var userDefaultsClient
+  @Dependency(\.pushNotificationAPIClient) private var pushNotificationAPIClient
   @Dependency(\.groupAPIClient) private var groupAPIClient
   
   public var body: some Reducer<State, Action> {
@@ -110,10 +118,14 @@ public struct LoginCore {
           if let idToken = state.kakaoIdToken.idToken,
              let nickname = state.kakaoUser.nickname,
              let profileImageUrl = state.kakaoUser.profileImageUrl?.absoluteString {
+            let token = try await firebaseClient.checkRegistrationToken()
+            await send(.getFCMToken(token))
             await send(.loginResponse(Result { try await authAPIClient.login(idToken, nickname, profileImageUrl) }))
           } else {
             await send(.loginResponse(.failure(LoginCoreError(code: .failToCheckUserInformation))))
           }
+        } catch: { error,send in
+          await send(.loginResponse(.failure(LoginCoreError(code: .failToRegistrationToken, underlying: error))))
         }
         
       case .checkUserInformationResponse(.failure):
@@ -140,6 +152,30 @@ public struct LoginCore {
         return .run { send in
           await send(.logError(LoginCoreError(code: .failToLogin)))
           await send(.showError(true))
+        }
+        
+      case let .getFCMToken(token):
+        state.FCMToken = token
+        return .run { send in
+          await send(.postFCMToken)
+        }
+        
+      case .postFCMToken:
+        return .run { [state] send in
+          await send(.responseFCMToken(Result {
+            try await self.pushNotificationAPIClient.registerFCMToken(
+              state.userInfo.accessToken,
+              state.FCMToken
+            )
+          }))
+        }
+        
+      case .responseFCMToken(.success):
+        return .none
+        
+      case .responseFCMToken(.failure):
+        return .run { send in
+          await send(.logError(LoginCoreError(code: .failToPostFCMToken)))
         }
         
       case .saveUserInfoToKeychain(.success):
@@ -183,8 +219,10 @@ public struct LoginCoreError: GabbangzipError {
   public var underlying: Error?
   
   public enum Code: Int {
+    case failToRegistrationToken
     case failToCheckUserInformation
     case failToLogin
+    case failToPostFCMToken
     case failToSaveUserInfoToKeychain
   }
 }

--- a/Projects/Features/Scene/MainScene/Group/GroupCore.swift
+++ b/Projects/Features/Scene/MainScene/Group/GroupCore.swift
@@ -95,7 +95,7 @@ public struct GroupCore {
     
     public enum Delegate {
       case headerButtonTapped(Int)
-      case createEventButtonTapped
+      case createEventButtonTapped(Int)
       case stabbingSuccessed
       case stabbingFailed
       case imageUploadSuccessed
@@ -117,7 +117,7 @@ public struct GroupCore {
         return .send(.delegate(.headerButtonTapped(state.id)))
         
       case .createEventButtonTapped:
-        return .send(.delegate(.createEventButtonTapped))
+        return .send(.delegate(.createEventButtonTapped(state.id)))
         
       case .stabbingButtonTapped:
         return .run { [state] send in

--- a/Projects/Features/Scene/MainScene/Home/HomeCore.swift
+++ b/Projects/Features/Scene/MainScene/Home/HomeCore.swift
@@ -65,7 +65,7 @@ public struct HomeCore {
     case moveToCreateGroup
     case moveToJoinGroup
     case moveToGroupDetail(Int)
-    case moveToCreateEvent
+    case moveToCreateEvent(Int)
     case moveToVote
   }
   
@@ -168,8 +168,8 @@ public struct HomeCore {
           switch delegate {
           case let .headerButtonTapped(groupID):
             await send(.moveToGroupDetail(groupID))
-          case .createEventButtonTapped:
-            await send(.moveToCreateEvent)
+          case let .createEventButtonTapped(groupID):
+            await send(.moveToCreateEvent(groupID))
           case .stabbingSuccessed:
             await send(.showToastMessage(.textWithCheckIcon("쿡찌르기 성공!")))
           case .stabbingFailed:


### PR DESCRIPTION
## 📌 Related Issue
- #116 
## 🚀 Description
- CreateEvent API 연동하였습니다.
- FCM RegisterFCMToken을 PIC 서버에 post하였습니다.
- CreateEvent View에서 사진 미리보기 가로 스크롤의 양옆 패딩을 삭제하였습니다.
## ✅ Done
- [x] Model 내부 불필요한 import 삭제
- [x] Login 완료 시 FCM Register Token 서버에 업로드
- [x] EventAPI 생성 - CreateEventInfo, UploadEventImageInfo, EventImageInfo, EventInfo 객체 생성
- [x] 에러 발생 시 " 다시 시도해주세요" 토스트 뷰
- [x] 이벤트 생성 시 이미지 업로드
## 📸 Screenshot
![Aug-17-2024 13-05-09](https://github.com/user-attachments/assets/6447545b-a8b7-4c9a-9c2c-00a83d17ed80)

## 📢 Notes
 - 현재 이미지 업로드 로직 순서가 fileUploadeAPIClient를 사용하여 UploadURL을 받고, 해당 UploadURL에 각각 한장씩의 사진 총 4장의 사진을 업로드한 후
사진의 s3 URL 배열값을 이벤트 생성 API (/api/v1/events)에 post 하고 있습니다.
그룹을 생성한 사람이 아닌 경우 이미지 업로드 API(/api/v1/events/images)를 로직을 추가해야합니다.