### PR TITLE
[Fix] 그룹 상세 관련 버그 수정

### DIFF
--- a/Projects/Features/Coordinator/GroupDetailCoordinator/GroupDetailCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/GroupDetailCoordinator/GroupDetailCoordinatorCore.swift
@@ -38,6 +38,15 @@ public struct GroupDetailCoordinatorCore {
       case let .router(.routeAction(id: _, action: .groupDetail(.moveToVote(eventID)))):
         state.routes.push(.vote(.init(eventID: eventID, isFromMain: false)))
         
+      case let .router(.routeAction(id: _, action: .groupDetail(.moveToCreateEvent(groupID)))):
+        state.routes.push(.createEvent(.init(groupID: groupID)))
+        
+      case .router(.routeAction(id: _, action: .createEvent(.moveToHome))):
+        state.routes.pop()
+        
+      case .router(.routeAction(id: _, action: .createEvent(.moveToHomeWithEvent))):
+        state.routes.pop()
+        
       case .router(.routeAction(id: _, action: .historyDetail(.backToGroupDetail))):
         state.routes.pop()
         

--- a/Projects/Features/Coordinator/GroupDetailCoordinator/GroupDetailCoordinatorCore.swift
+++ b/Projects/Features/Coordinator/GroupDetailCoordinator/GroupDetailCoordinatorCore.swift
@@ -32,8 +32,8 @@ public struct GroupDetailCoordinatorCore {
       case let .router(.routeAction(id: _, action: .groupDetail(.moveToHistoryDetail(history, keyword, domain)))):
         state.routes.push(.historyDetail(.init(history: history, keyword: keyword, s3BucketDomain: domain)))
         
-      case let .router(.routeAction(id: _, action: .groupDetail(.moveToMemberList(groupID)))):
-        state.routes.push(.memberList(.init(groupID: groupID)))
+      case let .router(.routeAction(id: _, action: .groupDetail(.moveToMemberList(groupID, groupKeyword)))):
+        state.routes.push(.memberList(.init(groupID: groupID, groupKeyword: groupKeyword)))
         
       case let .router(.routeAction(id: _, action: .groupDetail(.moveToVote(eventID)))):
         state.routes.push(.vote(.init(eventID: eventID, isFromMain: false)))

--- a/Projects/Features/Coordinator/GroupDetailCoordinator/GroupDetailCoordinatorView.swift
+++ b/Projects/Features/Coordinator/GroupDetailCoordinator/GroupDetailCoordinatorView.swift
@@ -7,6 +7,7 @@
 //
 
 import ComposableArchitecture
+import CreateEvent
 import GroupDetail
 import SwiftUI
 import TCACoordinators
@@ -32,6 +33,8 @@ public struct GroupDetailCoordinatorView: View {
           VoteView(store: store)
         case let .voteComplete(store):
           VoteCompleteView(store: store)
+        case let .createEvent(store):
+          CreateEventView(store: store)
         }
       }
       .toolbar(.hidden)

--- a/Projects/Features/Coordinator/GroupDetailCoordinator/GroupDetailScreen.swift
+++ b/Projects/Features/Coordinator/GroupDetailCoordinator/GroupDetailScreen.swift
@@ -7,6 +7,7 @@
 //
 
 import ComposableArchitecture
+import CreateEvent
 import GroupDetail
 import TCACoordinators
 
@@ -17,5 +18,6 @@ public enum GroupDetailScreen {
   case memberList(MemberListCore)
   case vote(VoteCore)
   case voteComplete(VoteCompleteCore)
+  case createEvent(CreateEventCore)
 }
 

--- a/Projects/Features/Coordinator/Project.swift
+++ b/Projects/Features/Coordinator/Project.swift
@@ -48,6 +48,7 @@ let project = Project.make(
       sources: ["GroupDetailCoordinator/**"],
       dependencies: [
         .project(target: .groupDetail, projectPath: .scene),
+        .project(target: .createEvent, projectPath: .scene),
         .external(externalDependency: .composableArchitecture),
         .external(externalDependency: .tcaCoordinators)
       ]

--- a/Projects/Features/Scene/GroupDetailScene/GroupDetail/EventContainer/EventCompletedView/EventCompletedView.swift
+++ b/Projects/Features/Scene/GroupDetailScene/GroupDetail/EventContainer/EventCompletedView/EventCompletedView.swift
@@ -40,6 +40,14 @@ public struct EventCompletedView: View {
 //      })
       .padding(.bottom, 32)
     }
+    .overlay {
+      if store.isNeedEventCompletedTitle {
+        LottieView(
+          type: .confetti,
+          loopMode: .playOnce
+        )
+      }
+    }
   }
   
   @ViewBuilder

--- a/Projects/Features/Scene/GroupDetailScene/GroupDetail/EventContainer/EventContainerView.swift
+++ b/Projects/Features/Scene/GroupDetailScene/GroupDetail/EventContainer/EventContainerView.swift
@@ -37,7 +37,9 @@ struct EventContainerView: View {
           },
           store: store
         )
-      case .noCurrentEvent, .eventCompleted:
+      case .noCurrentEvent:
+        EventDefaultView(store: store)
+      case .eventCompleted:
         EventCompletedView(store: store)
       case .noPastAndCurrentEvent:
         // 해당 화면에 접근 불가능한 조건

--- a/Projects/Features/Scene/GroupDetailScene/GroupDetail/EventContainer/EventDefaultView/EventDefaultView.swift
+++ b/Projects/Features/Scene/GroupDetailScene/GroupDetail/EventContainer/EventDefaultView/EventDefaultView.swift
@@ -1,8 +1,8 @@
 //
-//  EventCompletedView.swift
+//  EventDefaultView.swift
 //  GroupDetail
 //
-//  Created by hyerin on 8/11/24.
+//  Created by hyerin on 8/29/24.
 //  Copyright © 2024 com.mashup.gabbangzip. All rights reserved.
 //
 
@@ -13,7 +13,7 @@ import Lovebug
 import Models
 import SwiftUI
 
-public struct EventCompletedView: View {
+public struct EventDefaultView: View {
   @Bindable var store: StoreOf<GroupDetailCore>
   
   public init(store: StoreOf<GroupDetailCore>) {
@@ -22,27 +22,17 @@ public struct EventCompletedView: View {
   
   public var body: some View {
     VStack(spacing: 0) {
-      Text("네컷 사진이 만들어졌어요!")
-        .foregroundStyle(DesignSystem.Colors.gray80)
-        .font(.head20)
-      
       completedImage
       .padding(.horizontal, 41.5)
       .padding(.vertical, 16)
-//      TODO: 공유하기 이미지 캡쳐 추후 확인 필요
-//      ShareButton(action: {
-//        captureView(of: completedImage) { capturedImage in
-//          store.send(.imageCaptured(capturedImage))
-//          store.send(.shareButtonTapped)
-//        }
-//      })
+
+      SmallButton(
+        type: .active,
+        smallButtonContentType: .generateEvent
+      ) {
+        store.send(.createEventButtonTapped)
+      }
       .padding(.bottom, 32)
-    }
-    .overlay {
-      LottieView(
-        type: .confetti,
-        loopMode: .playOnce
-      )
     }
   }
   

--- a/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailCore.swift
+++ b/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailCore.swift
@@ -139,6 +139,7 @@ public struct GroupDetailCore {
     case showToast(DetailToastType)
     case photosPickerPresentedChanged(Bool)
     case selectedPickerItemsChanged([PhotosPickerItem])
+    case reloadGroupDetail
 
     // Route Action
     case backToHome
@@ -342,6 +343,7 @@ public struct GroupDetailCore {
               )
               
               await send(.showToast(.imageUploadSuccess))
+              await send(.reloadGroupDetail)
             }
           },
           catch: { error, send in
@@ -349,6 +351,13 @@ public struct GroupDetailCore {
             await send(.showToast(.imageUploadFail))
           }
         )
+        
+      case .reloadGroupDetail:
+        return .run { [state] send in
+          await send(.getGroupDetailResponse(Result {
+            try await self.groupAPIClient.getGroupDetail(state.userInfo.accessToken, state.groupID)
+          }))
+        }
         
       case .moveToCreateEvent:
         return .none

--- a/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailCore.swift
+++ b/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailCore.swift
@@ -145,7 +145,7 @@ public struct GroupDetailCore {
 
     // Route Action
     case backToHome
-    case moveToMemberList(Int)
+    case moveToMemberList(Int, GroupData.Keyword)
     case moveToVote(Int)
     case moveToHistoryDetail(History, GroupData.Keyword?, String)
   }
@@ -178,7 +178,7 @@ public struct GroupDetailCore {
         
       case .memberListButtonTapped:
         state.showSheet = false
-        return .send(.moveToMemberList(state.groupID))
+        return .send(.moveToMemberList(state.groupID, state.groupDetail?.keyword ?? .company))
         
       case let .eventContainerViewButtonTapped(status):
         switch status {

--- a/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailCore.swift
+++ b/Projects/Features/Scene/GroupDetailScene/GroupDetail/GroupDetailCore.swift
@@ -51,11 +51,7 @@ public struct GroupDetailCore {
         return .generateEvent
       }
     }
-    
-    var isNeedEventCompletedTitle: Bool {
-      return groupDetail?.status == .eventCompleted
-    }
-    
+
     var frame: Image {
       return groupDetail?.keyword.frame ?? DesignSystem.Icons.plusFrame
     }
@@ -133,6 +129,7 @@ public struct GroupDetailCore {
     case shareButtonTapped
     case galleryButtonTapped
     case imageCaptured(UIImage?)
+    case createEventButtonTapped
 
     // Internal Action
     case setS3BucketDomain(String)
@@ -148,6 +145,7 @@ public struct GroupDetailCore {
     case moveToMemberList(Int, GroupData.Keyword)
     case moveToVote(Int)
     case moveToHistoryDetail(History, GroupData.Keyword?, String)
+    case moveToCreateEvent(Int)
   }
 
   public var body: some Reducer<State, Action> {
@@ -215,6 +213,9 @@ public struct GroupDetailCore {
       case let .imageCaptured(image):
         state.capturedImage = image
         return .none
+        
+      case .createEventButtonTapped:
+        return .send(.moveToCreateEvent(state.groupID))
         
       case let .setS3BucketDomain(s3BucketDomain):
         state.s3BucketDomain = s3BucketDomain
@@ -348,6 +349,9 @@ public struct GroupDetailCore {
             await send(.showToast(.imageUploadFail))
           }
         )
+        
+      case .moveToCreateEvent:
+        return .none
       }
     }
   }

--- a/Projects/Features/Scene/GroupDetailScene/GroupDetail/HistoryGrid/HistoryItemView.swift
+++ b/Projects/Features/Scene/GroupDetailScene/GroupDetail/HistoryGrid/HistoryItemView.swift
@@ -41,7 +41,7 @@ struct HistoryItemView: View {
         .foregroundStyle(DesignSystem.Colors.gray80)
         .padding(.bottom, 4)
       
-      Text(history.date)
+      Text(history.date.toGroupEventDateString(type: .eventDate) ?? "")
         .font(.caption12)
         .foregroundStyle(DesignSystem.Colors.gray60)
     }

--- a/Projects/Features/Scene/GroupDetailScene/MemberList/MemberListCore.swift
+++ b/Projects/Features/Scene/GroupDetailScene/MemberList/MemberListCore.swift
@@ -30,7 +30,7 @@ public struct MemberListCore {
     public init(
       groupID: Int,
       memberList: MemberList? = nil,
-      groupKeyword: GroupData.Keyword = .company,
+      groupKeyword: GroupData.Keyword,
       userInfo: @autoclosure () -> UserInfo = .defaultValue
     ) {
       self.groupID = groupID

--- a/Projects/Features/Scene/GroupDetailScene/MemberList/MemberListCore.swift
+++ b/Projects/Features/Scene/GroupDetailScene/MemberList/MemberListCore.swift
@@ -7,6 +7,7 @@
 //
 
 import ComposableArchitecture
+import DesignSystem
 import Models
 import Services
 
@@ -19,6 +20,8 @@ public struct MemberListCore {
     var groupID: Int
     var memberList: MemberList?
     var groupKeyword: GroupData.Keyword
+    var toastPresented: Bool
+    var toastType: MemberListToastType
     var isFullCapacity: Bool {
       memberList?.members.count == 4
     }
@@ -31,18 +34,23 @@ public struct MemberListCore {
       groupID: Int,
       memberList: MemberList? = nil,
       groupKeyword: GroupData.Keyword,
+      toastPresented: Bool = false,
+      toastType: MemberListToastType = .codeCopied,
       userInfo: @autoclosure () -> UserInfo = .defaultValue
     ) {
       self.groupID = groupID
       self.memberList = memberList
       self.groupKeyword = groupKeyword
+      self.toastPresented = toastPresented
+      self.toastType = toastType
       self._userInfo = Shared(wrappedValue: userInfo(), .inMemory("userInfo"))
     }
   }
   
   @Dependency(\.groupAPIClient) var groupAPIClient
 
-  public enum Action {
+  public enum Action: BindableAction {
+    case binding(BindingAction<State>)
     // View Action
     case onAppear
     case copyCodeButtonTapped
@@ -50,6 +58,7 @@ public struct MemberListCore {
     
     // Internal Action
     case getMemberList(Result<MemberList, Error>)
+    case showToast(MemberListToastType)
     
     // Route Action
     case backToGroupDetail
@@ -60,6 +69,9 @@ public struct MemberListCore {
   public var body: some Reducer<State, Action> {
     Reduce { state, action in
       switch action {
+      case .binding:
+        return .none
+        
       case .onAppear:
         return .run(
           operation: { [state] send in
@@ -72,6 +84,7 @@ public struct MemberListCore {
       case .copyCodeButtonTapped:
         return .run { [state] send in
           uiPasteBoardClient.copyTextToClipboard(state.memberList?.invitationCode ?? "")
+          await send(.showToast(.codeCopied))
         }
         
       case .backButtonTapped:
@@ -86,6 +99,24 @@ public struct MemberListCore {
         
       case .backToGroupDetail:
         return .none
+        
+      case let .showToast(toastType):
+        state.toastPresented = true
+        state.toastType = toastType
+        return .none
+      }
+    }
+  }
+}
+
+extension MemberListCore {
+  public enum MemberListToastType {
+    case codeCopied
+    
+    var toast: ToastType {
+      switch self {
+      case .codeCopied:
+        return .onlyText("그룹원 초대 코드가 복사됐습니다!")
       }
     }
   }

--- a/Projects/Features/Scene/GroupDetailScene/MemberList/MemberListView.swift
+++ b/Projects/Features/Scene/GroupDetailScene/MemberList/MemberListView.swift
@@ -12,7 +12,7 @@ import Models
 import SwiftUI
 
 public struct MemberListView: View {
-  private let store: StoreOf<MemberListCore>
+  @Bindable private var store: StoreOf<MemberListCore>
 
   public init(store: StoreOf<MemberListCore>) {
     self.store = store
@@ -52,6 +52,10 @@ public struct MemberListView: View {
       
       Spacer()
     }
+    .toast(
+      isPresented: $store.toastPresented,
+      type: store.toastType.toast
+    )
     .onAppear { store.send(.onAppear) }
   }
 }


### PR DESCRIPTION
## 📌 Related Issue
- #132 

## 🚀 Description
그룹 상세 관련 버그 수정했습니다.

## ✅ Done
- [x] 멤버목록 키워드에 맞춰서 이미지 변경되게 수정
- [x] 멤버목록에서 코드 복사했을 때 토스트 띄우도록 수정
- [x] 내 PIC 올리기 후 상태 업데이트 되도록 수정
- [x] 투표 완료 시 그룹 상태 업데이트 되도록 수정
- [x] noCurrentEvent인 경우 이벤트 만들기 버튼 뜨도록 수정
- [x] 네컷 생성 완료 시 로띠 추가
- [x] 이벤트 목록 날짜 포맷 수정

## 📸 Screenshot

## 📢 Notes
 
## 🧪 Testing(optional)
