### PR TITLE
[FIX] 애플로그인버튼 코너값 수정, 이벤트->네컷 명명 수정

### DIFF
--- a/Projects/DesignSystem/Sources/Views/Button/SmallButton.swift
+++ b/Projects/DesignSystem/Sources/Views/Button/SmallButton.swift
@@ -155,7 +155,7 @@ public enum SmallButtonContentType {
   case changeFrame
   // 쿡 찌르기
   case stabbing
-  // 이벤트 생성하기
+  // 네컷 생성하기
   case generateEvent
   // 투표하기
   case vote
@@ -188,7 +188,7 @@ public enum SmallButtonContentType {
     case .stabbing:
       "쿡 찌르기"
     case .generateEvent:
-      "이벤트 생성하기"
+      "네컷 생성하기"
     case .vote:
       "투표하기"
     }

--- a/Projects/Features/Scene/CreateEventScene/CreateEventView.swift
+++ b/Projects/Features/Scene/CreateEventScene/CreateEventView.swift
@@ -86,7 +86,7 @@ public struct CreateEventView: View {
   }
 }
 
-// MARK: - 이벤트 한줄 요약 뷰
+// MARK: - 네컷 한줄 요약 뷰
 fileprivate struct EventView: View {
   private var text: String
   
@@ -213,9 +213,9 @@ fileprivate struct EventPicturePickerView: View {
 // MARK: - CreateEventViewNameSpace
 extension CreateEventView {
   fileprivate enum CreateEventViewNameSpace {
-    static let navigationTitle = "이벤트 만들기"
-    static let eventTitle = "이벤트 한줄 요약"
-    static let eventTitlePlaceHolder = "이벤트를 한줄로 요약해주세요."
+    static let navigationTitle = "네컷 만들기"
+    static let eventTitle = "네컷 약속 한줄 요약"
+    static let eventTitlePlaceHolder = "어떤 약속인지 요약해 주세요"
     static let eventDate = "날짜"
     static let eventDatePlaceHolder = "YY/MM/DD"
     static let eventPicture = "사진 선택"
@@ -223,7 +223,7 @@ extension CreateEventView {
     static let popupDescription = "페이지를 나가면\n작성중인 내용이 삭제돼요"
     static let popupLeftButtonTitle = "나가기"
     static let popupRightButtonTitle = "계속 작성하기"
-    static let notice = "이벤트 PIC은 2시간 후에 종료돼요."
+    static let notice = "네컷 PIC은 2시간 후에 종료돼요."
     static let complete = "완료"
   }
 }

--- a/Projects/Features/Scene/GroupDetailScene/GroupDetail/HistoryGrid/HistoryGridView.swift
+++ b/Projects/Features/Scene/GroupDetailScene/GroupDetail/HistoryGrid/HistoryGridView.swift
@@ -79,7 +79,7 @@ struct HistoryGridView: View {
       DesignSystem.Images.empty
         .padding(.bottom, 16)
       
-      Text("그룹 이벤트를 만들고\n우리끼리 PIC으로 인생 네컷을 모아보세요.")
+      Text("네컷 사진이 만들어지면\n이곳에 추가돼요.")
         .multilineTextAlignment(.center)
         .foregroundStyle(DesignSystem.Colors.gray60)
         .font(.text14)

--- a/Projects/Features/Scene/LoginScene/Login/LoginView.swift
+++ b/Projects/Features/Scene/LoginScene/Login/LoginView.swift
@@ -65,6 +65,7 @@ public struct LoginView: View {
           store.send(.appleSignInCompleted(result))
         }
       )
+      .cornerRadius(12)
       .frame(height: 50)
       .padding(.horizontal, 16)
       .padding(.top, 8)

--- a/Projects/Features/Scene/MainScene/Group/GroupCore.swift
+++ b/Projects/Features/Scene/MainScene/Group/GroupCore.swift
@@ -47,7 +47,7 @@ public struct GroupCore {
       return recentEvent.name ?? ""
     }
     var frontTitle: String {
-      return status == .noPastAndCurrentEvent ? "이벤트를 만들어 보세요!" : recentEventDate
+      return status == .noPastAndCurrentEvent ? "네컷을 만들어 보세요!" : recentEventDate
     }
     var isAllPhotoAdded: Bool {
       return selectedPhotosInfo.count == 4

--- a/Projects/Features/Scene/MainScene/Group/Views/GroupHeaderView.swift
+++ b/Projects/Features/Scene/MainScene/Group/Views/GroupHeaderView.swift
@@ -40,5 +40,5 @@ struct GroupHeaderView: View {
 }
 
 #Preview {
-  GroupHeaderView(title: "이벤트를 만들어 보세요!", isButtonStyle: false)
+  GroupHeaderView(title: "네컷을 만들어 보세요!", isButtonStyle: false)
 }


### PR DESCRIPTION
## 📌 Related Issue
- #147 
## 🚀 Description
- 디자인 수정에따른 업데이트

## ✅ Done
- 애플로그인 버튼 코너값 12 적용
- 이벤트 관련 명명 수정
## 📸 Screenshot
![스크린샷 2024-09-21 오후 5 32 52](https://github.com/user-attachments/assets/20fed2ad-16ca-4251-89ae-3aa9a128a01a)