### PR TITLE
[Hotfix] 그룹 코드 복사 양식 수정

### DIFF
--- a/Projects/Features/Scene/CreateGroupScene/CreateGroupCompletion/CreateGroupCompletionCore.swift
+++ b/Projects/Features/Scene/CreateGroupScene/CreateGroupCompletion/CreateGroupCompletionCore.swift
@@ -72,7 +72,14 @@ public struct CreateGroupCompletionCore {
         state.toastPresented = true
         
         return .run { [state] send in
-          uiPasteBoardClient.copyTextToClipboard(state.createdGroupInfo.invitationCode)
+          uiPasteBoardClient.copyTextToClipboard(
+            """
+            PIC 앱 다운받기
+            - PlayStore: https://play.google.com/store/apps/details?id=com.mashup.gabbangzip.sharedalbum
+            - AppStore: https://apps.apple.com/kr/app/PIC/id6503334452
+            초대코드: \(state.createdGroupInfo.invitationCode)
+            """
+          )
         }
         
       case let .setImageURLString(urlString):

--- a/Projects/Features/Scene/GroupDetailScene/MemberList/MemberListCore.swift
+++ b/Projects/Features/Scene/GroupDetailScene/MemberList/MemberListCore.swift
@@ -83,7 +83,14 @@ public struct MemberListCore {
         
       case .copyCodeButtonTapped:
         return .run { [state] send in
-          uiPasteBoardClient.copyTextToClipboard(state.memberList?.invitationCode ?? "")
+          uiPasteBoardClient.copyTextToClipboard(
+            """
+            PIC 앱 다운받기
+            - PlayStore: https://play.google.com/store/apps/details?id=com.mashup.gabbangzip.sharedalbum
+            - AppStore: https://apps.apple.com/kr/app/PIC/id6503334452
+            초대코드: \(state.memberList?.invitationCode ?? "")
+            """
+          )
           await send(.showToast(.codeCopied))
         }
         


### PR DESCRIPTION
## 📌 Related Issue
- #151 
## 🚀 Description
- 그룹 코드 복사 시 앱 다운로드 링크 첨부되도록 수정
## ✅ Done
- MemberListCore의 copyCodeButtonTapped 시 코드 양식 변경
- CreateGroupCompletionCore에서 코드 양식 변경
