### PR TITLE
[Hotfix] 그룹 생성 시 사진 업로드 동안 인디케이터 노출

### DIFF
--- a/Projects/Features/Scene/CreateGroupScene/SelectGroupPhoto/SelectGroupPhotoCore.swift
+++ b/Projects/Features/Scene/CreateGroupScene/SelectGroupPhoto/SelectGroupPhotoCore.swift
@@ -25,6 +25,7 @@ public struct SelectGroupPhotoCore {
     var keyword: GroupData.Keyword
     var selectedPhotoInfo: PhotoInfo?
     var isFromGetStarted: Bool
+    var isLoading: Bool
     var photosPickerPresented: Bool
     var selectedPickerItems: [PhotosPickerItem]
     var nextButtonType: ButtonType {
@@ -38,6 +39,7 @@ public struct SelectGroupPhotoCore {
       keyword: GroupData.Keyword,
       selectedPhotoInfo: PhotoInfo? = nil,
       isFromGetStarted: Bool,
+      isLoading: Bool = false,
       photosPickerPresented: Bool = false,
       selectedPickerItems: [PhotosPickerItem] = []
     ) {
@@ -47,6 +49,7 @@ public struct SelectGroupPhotoCore {
       self.keyword = keyword
       self.selectedPhotoInfo = selectedPhotoInfo
       self.isFromGetStarted = isFromGetStarted
+      self.isLoading = isLoading
       self.photosPickerPresented = photosPickerPresented
       self.selectedPickerItems = selectedPickerItems
     }
@@ -65,6 +68,7 @@ public struct SelectGroupPhotoCore {
     case uploadFileToPresignedURLResponse(Result<Void, Error>, FileUploadInfo)
     case createGroupResponse(Result<CreatedGroupInfo, Error>)
     case setSelectedPhotoInfo(PhotoInfo)
+    case setIsLoading(Bool)
     
     // Route Action
     case moveToCreateGroupCompletion(createdGroupInfo: CreatedGroupInfo, isFromGetStarted: Bool)
@@ -78,6 +82,7 @@ public struct SelectGroupPhotoCore {
     Reduce { state, action in
       switch action {
       case .nextButtonTapped:
+        state.isLoading = true
         return .run { [state] send in
           if let photoInfo = state.selectedPhotoInfo {
             await send(
@@ -166,6 +171,7 @@ public struct SelectGroupPhotoCore {
       case let .uploadFileToPresignedURLResponse(.failure(error), _):
         return .run { send in
           logger.error(error.localizedDescription)
+          await send(.setIsLoading(false))
         }
         
       case let .createGroupResponse(.success(createdGroupInfo)):
@@ -175,10 +181,15 @@ public struct SelectGroupPhotoCore {
       case let .createGroupResponse(.failure(error)):
         return .run { send in
           logger.error(error.localizedDescription)
+          await send(.setIsLoading(false))
         }
         
       case let .setSelectedPhotoInfo(photoInfo):
         state.selectedPhotoInfo = photoInfo
+        return .none
+        
+      case let .setIsLoading(value):
+        state.isLoading = value
         return .none
 
       case .moveToCreateGroupCompletion:

--- a/Projects/Features/Scene/CreateGroupScene/SelectGroupPhoto/SelectGroupPhotoView.swift
+++ b/Projects/Features/Scene/CreateGroupScene/SelectGroupPhoto/SelectGroupPhotoView.swift
@@ -72,6 +72,20 @@ public struct SelectGroupPhotoView: View {
       maxSelectionCount: 1,
       matching: .images
     )
+    .overlay {
+      if store.isLoading {
+        ZStack {
+          Color.black
+            .opacity(0.5)
+            .ignoresSafeArea()
+          
+          ProgressView()
+            .progressViewStyle(CircularProgressViewStyle())
+            .controlSize(.large)
+            .tint(.white)
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## 📌 Related Issue
- #153 
## 🚀 Description
- 그룹 생성 시 그룹 대표 사진 업로드 동안 인디케이터 뷰 노출
## ✅ Done
- SelectGroupPhotoCore, View 수정
## 📸 Screenshot
![Sep-22-2024 01-07-51](https://github.com/user-attachments/assets/fbbbfbb5-d58e-41fc-bba4-2957580c69ae)

