### PR TITLE
[Fix] 공유 버튼 완료 시 disable되도록 수정

### DIFF
--- a/Projects/Features/Scene/GroupDetailScene/HistoryDetail/HistoryDetailCore.swift
+++ b/Projects/Features/Scene/GroupDetailScene/HistoryDetail/HistoryDetailCore.swift
@@ -52,8 +52,9 @@ public struct HistoryDetailCore {
     // View Action
     case backButtonTapped
     case shareButtonTapped
+    case completeActivity
     
-    //
+    // Internal Action
     case imageCaptured(UIImage?)
     case imageAllLoaded([ImageModel])
     
@@ -72,6 +73,10 @@ public struct HistoryDetailCore {
         
       case .shareButtonTapped:
         state.showActivityView = true
+        return .none
+        
+      case .completeActivity:
+        state.showActivityView = false
         return .none
         
       case let .imageCaptured(image):

--- a/Projects/Features/Scene/GroupDetailScene/HistoryDetail/HistoryDetailView.swift
+++ b/Projects/Features/Scene/GroupDetailScene/HistoryDetail/HistoryDetailView.swift
@@ -47,8 +47,8 @@ public struct HistoryDetailView: View {
               scale: scale,
               size: CGSize(width: 310, height: 420)
             ) { capturedImage in
-              store.send(.imageCaptured(capturedImage))
               store.send(.shareButtonTapped)
+              store.send(.imageCaptured(capturedImage))
             }
           }
         }
@@ -60,7 +60,9 @@ public struct HistoryDetailView: View {
       ActivityView(
         isPresented: $store.showActivityView,
         activityItems: [store.capturedImage]
-      )
+      ) {
+        store.send(.completeActivity)
+      }
     )
   }
   


### PR DESCRIPTION
## 📌 Related Issue
- #168 
## 🚀 Description
- 공유 버튼 클릭 후 ActivityView가 내려가지 않는 문제 해결
## ✅ Done
- ActivityView completioin에 Bool값 수정하는 Action 추가
## 📸 Screenshot
![Oct-03-2024 06-28-15](https://github.com/user-attachments/assets/164465f0-4dcd-4ebb-98c5-aceb6dcba9bb)
