### PR TITLE
[Fix] 문구, 폰트, 크기, 아이콘 수정 및 로그아웃 버그 수정

### DIFF
--- a/Projects/DesignSystem/Sources/Views/Chip/Tag.swift
+++ b/Projects/DesignSystem/Sources/Views/Chip/Tag.swift
@@ -10,9 +10,17 @@ import SwiftUI
 
 public struct Tag: View {
   private var type: TagType
+  private var displayMode: DisplayMode
+  private var font: Font
   
-  public init(type: TagType) {
+  public init(
+    type: TagType,
+    displayMode: DisplayMode = .light,
+    font: Font = .body12
+  ) {
     self.type = type
+    self.displayMode = displayMode
+    self.font = font
   }
   
   public var body: some View {
@@ -29,8 +37,28 @@ public struct Tag: View {
         )
       }
     }
-    .background(DesignSystem.Colors.gray40)
+    .font(font)
+    .foregroundStyle(textColor)
+    .background(chipColor)
     .cornerRadius(20)
+  }
+  
+  private var textColor: Color {
+    switch displayMode {
+    case .light:
+      return DesignSystem.Colors.gray80
+    case .dark:
+      return DesignSystem.Colors.gray40
+    }
+  }
+  
+  private var chipColor: Color {
+    switch displayMode {
+    case .light:
+      return DesignSystem.Colors.gray40
+    case .dark:
+      return DesignSystem.Colors.gray100
+    }
   }
 }
 
@@ -49,8 +77,7 @@ fileprivate struct CategoryTag: View {
         .frame(width: 10, height: 10)
       
       Text(type.title)
-        .font(.body12)
-        .foregroundStyle(DesignSystem.Colors.gray80)
+//        .font(.body12)
     }
     .padding(.vertical, 6)
     .padding(.horizontal, 10)
@@ -67,8 +94,7 @@ fileprivate struct EtcTag: View {
   
   fileprivate var body: some View {
     Text(type.title)
-      .font(.body12)
-      .foregroundStyle(DesignSystem.Colors.gray80)
+//      .font(.body12)
       .padding(.vertical, 6)
       .padding(.horizontal, 10)
   }
@@ -78,6 +104,11 @@ fileprivate struct EtcTag: View {
 public enum TagType {
   case category(CategoryType)
   case etc(EtcType)
+}
+
+public enum DisplayMode {
+  case light
+  case dark
 }
 
 #Preview {
@@ -93,8 +124,23 @@ public enum TagType {
     }
     
     VStack {
+      Tag(type: .category(.crew), displayMode: .dark)
+      Tag(type: .category(.network), displayMode: .dark)
+      Tag(type: .category(.company), displayMode: .dark)
+      Tag(type: .category(.exercise), displayMode: .dark)
+      Tag(type: .category(.littleMoim), displayMode: .dark)
+      Tag(type: .category(.hobby), displayMode: .dark)
+      Tag(type: .category(.school), displayMode: .dark)
+    }
+    
+    VStack {
       Tag(type: .etc(.voting))
       Tag(type: .etc(.update(3)))
+    }
+    
+    VStack {
+      Tag(type: .etc(.voting), displayMode: .dark)
+      Tag(type: .etc(.update(3)), displayMode: .dark)
     }
   }
 }

--- a/Projects/Features/Scene/CreateGroupScene/CreateGroupCompletion/CreateGroupCompletionView.swift
+++ b/Projects/Features/Scene/CreateGroupScene/CreateGroupCompletion/CreateGroupCompletionView.swift
@@ -78,7 +78,7 @@ public struct CreateGroupCompletionView: View {
     .onAppear { store.send(.onAppear) }
     .toast(
       isPresented: $store.toastPresented.sending(\.setToastPresented),
-      type: .textWithCheckIcon("링크를 복사했어요.")
+      type: .textWithCheckIcon("코드를 복사했어요.")
     )
   }
 }

--- a/Projects/Features/Scene/CreateGroupScene/CreateGroupCompletion/CreateGroupCompletionView.swift
+++ b/Projects/Features/Scene/CreateGroupScene/CreateGroupCompletion/CreateGroupCompletionView.swift
@@ -35,7 +35,7 @@ public struct CreateGroupCompletionView: View {
       
       PhotoCard(status: store.createdGroupInfo.keyword.convertToPhotoCardStatus()) {
         VStack(spacing: 0) {
-          Tag(type: store.createdGroupInfo.keyword.tagType)
+          Tag(type: store.createdGroupInfo.keyword.tagType, displayMode: .dark)
           
           PhotoWithFrame(
             frameShape: store.createdGroupInfo.keyword.frame,

--- a/Projects/Features/Scene/CreateGroupScene/CreateGroupCompletion/CreateGroupCompletionView.swift
+++ b/Projects/Features/Scene/CreateGroupScene/CreateGroupCompletion/CreateGroupCompletionView.swift
@@ -31,7 +31,8 @@ public struct CreateGroupCompletionView: View {
         .font(.head18)
         .foregroundStyle(DesignSystem.Colors.gray80)
         .padding(.horizontal, 16)
-        .padding(.vertical, 32)
+        .padding(.top, 32)
+        .padding(.bottom, 16)
       
       PhotoCard(status: store.createdGroupInfo.keyword.convertToPhotoCardStatus()) {
         VStack(spacing: 0) {
@@ -72,7 +73,10 @@ public struct CreateGroupCompletionView: View {
         title: "완료",
         action: { store.send(.completeButtonTapped) }
       )
-      .padding(.horizontal, 16)
+      .frame(height: 57)
+      .clipped()
+      .cornerRadius(16)
+      .padding(.horizontal, 22)
       .padding(.bottom, 12)
     }
     .onAppear { store.send(.onAppear) }

--- a/Projects/Features/Scene/CreateGroupScene/CreateGroupCompletion/CreateGroupCompletionView.swift
+++ b/Projects/Features/Scene/CreateGroupScene/CreateGroupCompletion/CreateGroupCompletionView.swift
@@ -59,7 +59,7 @@ public struct CreateGroupCompletionView: View {
         .padding(.top, 16)
       
       SmallButton(
-        type: .active,
+        type: .secondary,
         smallButtonContentType: .copyCode,
         action: { store.send(.copyLinkButtonTapped) }
       )

--- a/Projects/Features/Scene/MainScene/Group/Views/PhotoCardFrontView.swift
+++ b/Projects/Features/Scene/MainScene/Group/Views/PhotoCardFrontView.swift
@@ -34,6 +34,7 @@ struct PhotoCardFrontView: View {
       Text(title)
       .font(.body16)
       .foregroundStyle(DesignSystem.Colors.gray80)
+      .padding(.bottom, 6)
       
       PhotoWithFrame(
         frameShape: keyword.frame,

--- a/Projects/Features/Scene/MainScene/Home/GroupGrid/GroupGridView.swift
+++ b/Projects/Features/Scene/MainScene/Home/GroupGrid/GroupGridView.swift
@@ -31,8 +31,9 @@ public struct GroupGridView: View {
           }
         }
       )
+      .padding(.horizontal, 16)
+      .padding(.top, 18)
     }
-    .padding(.horizontal, 18)
   }
 }
 

--- a/Projects/Features/Scene/MainScene/Home/GroupGridItem/GroupGridItemView.swift
+++ b/Projects/Features/Scene/MainScene/Home/GroupGridItem/GroupGridItemView.swift
@@ -34,9 +34,9 @@ public struct GroupGridItemView: View {
         .foregroundStyle(DesignSystem.Colors.gray80)
       
       HStack {
-        Tag(type: store.keyword.tagType)
+        Tag(type: store.keyword.tagType, font: .body10)
         
-        Tag(type: .etc(.custom(store.statusDescription)))
+        Tag(type: .etc(.custom(store.statusDescription)), font: .body10)
         
         Spacer(minLength: 0)
       }

--- a/Projects/Features/Scene/MainScene/Home/HomeView.swift
+++ b/Projects/Features/Scene/MainScene/Home/HomeView.swift
@@ -34,14 +34,14 @@ public struct HomeView: View {
           switch store.displayMode {
           case .list:
             Button(action: { store.send(.displayModeChanged(.grid)) }) {
-              DesignSystem.Icons.list
+              DesignSystem.Icons.grid
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 18, height: 18)
             }
           case .grid:
             Button(action: { store.send(.displayModeChanged(.list)) }) {
-              DesignSystem.Icons.grid
+              DesignSystem.Icons.list
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 18, height: 18)

--- a/Projects/Features/Scene/MainScene/Home/HomeView.swift
+++ b/Projects/Features/Scene/MainScene/Home/HomeView.swift
@@ -53,6 +53,11 @@ public struct HomeView: View {
       }
       .frame(height: 40)
       
+      Divider()
+        .frame(height: 8)
+        .overlay(DesignSystem.Colors.gray20)
+        .padding(.top, 12)
+      
       switch store.state.displayMode {
       case .list:
         GroupListView(store: store.scope(state: \.groupList, action: \.groupList))

--- a/Projects/Features/Scene/MyPageScene/MyPage/MyPageCore.swift
+++ b/Projects/Features/Scene/MyPageScene/MyPage/MyPageCore.swift
@@ -209,9 +209,11 @@ public struct MyPageCore {
         
       case .logout:
         return .run(
-          operation: { send in
+          operation: { [state] send in
             try await keyChainClient.deleteUserInfo()
-            try await keyChainClient.deleteRefreshToken()
+            if case .apple = state.userInfo.loginType {
+              try await keyChainClient.deleteRefreshToken()
+            }
             await send(.backToLogin)
           },
           catch: { error, send in

--- a/Tuist/ResourceSynthesizers/Fonts.stencil
+++ b/Tuist/ResourceSynthesizers/Fonts.stencil
@@ -87,6 +87,12 @@ import SwiftUI
     }
     return Font(uiFont: font)
   }
+  {{accessModifier}} var _10: Font {
+    guard let font = UIFont(font: self, size: 10) else {
+      fatalError("Unable to initialize font name: '\(name)', family: \(family), size: 10")
+    }
+    return Font(uiFont: font)
+  }
 
   {{accessModifier}} func font(size: CGFloat) -> Font {
     guard let font = UIFont(font: self, size: size) else {
@@ -144,6 +150,9 @@ import SwiftUI
   }
   static var body12: Font {
     {{param.name}}FontFamily.{{family.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}.medium._12
+  }
+  static var body10: Font {
+    {{param.name}}FontFamily.{{family.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}.medium._10
   }
   static var text14: Font {
     {{param.name}}FontFamily.{{family.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}.regular._14


### PR DESCRIPTION
## 📌 Related Issue
- #173 

## 🚀 Description
- 문구, 폰트, 크기, 아이콘 수정 및 로그아웃 버그 수정

## ✅ Done
- [x] 카톡으로 로그인 한 경우 로그아웃이 안 되는 이슈
- [x] 홈 화면 디스플레이 모드 버튼의 로고 맞바꾸기
- [x] 컨텐츠 나누는 영역 생성 
- [x] 홈 화면의 그리드 상태에 대한 태그 폰트 크기 수정
- [x] 그리드 화면의 스크롤뷰의 패딩 조정
- [x] 카드 내 컴포넌트 위치 수정
- [x] 그룹 생성 완료 버튼 크기 및 전체적인 위치 수정
- [x] 그룹 생성 코드복사 컴포넌트 색상 변경
- [x] 그룹 생성 화면의 프레임 상단 태그 색상 변경
- [x] 그룹 생성 문구 수정
- [x] tag에 테마 및 폰트 파라미터 추가

## 📸 Screenshot
<img src="https://github.com/user-attachments/assets/adaad50b-50e0-4aef-be73-e96933f56ee1" width="200" height="450">
<img src="https://github.com/user-attachments/assets/22bc7ea5-046e-4800-86ac-7d6861a7c7f5" width="200" height="450">
<img src="https://github.com/user-attachments/assets/208d2275-9a34-4938-8bc3-6a35203dc7a6" width="200" height="450">


## 📢 Notes
 
## 🧪 Testing(optional)
